### PR TITLE
Add SLOW_SCRIPT_PAGE_COUNT to ErrorAggregator stats

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -49,6 +49,7 @@ object ErrorAggregator {
     .add[Int]("PERMISSIONS_SQL_CORRUPTED")
     .add[Int]("DEFECTIVE_PERMISSIONS_SQL_REMOVED")
     .add[Int]("SLOW_SCRIPT_NOTICE_COUNT")
+    .add[Int]("SLOW_SCRIPT_PAGE_COUNT")
     .build
 
   private val dimensionsSchema = new SchemaBuilder()


### PR DESCRIPTION
This is one of the metrics suggested by releng.
I will use it to test schema updates as per #19