### PR TITLE
Prod

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,9 @@ lazy val root = (project in file(".")).
   settings(
     libraryDependencies += "com.mozilla.telemetry" %% "moztelemetry" % "1.0-SNAPSHOT",
     libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-    libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion,
-    libraryDependencies += "org.apache.spark" %% "spark-streaming" % sparkVersion,
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion,
+    libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
+    libraryDependencies += "org.apache.spark" %% "spark-streaming" % sparkVersion % "provided",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
     libraryDependencies += "org.apache.spark" %% "spark-sql-kafka-0-10" % sparkVersion,
     libraryDependencies += "org.rogach" %% "scallop" % "1.0.2",
     libraryDependencies += "com.google.protobuf" % "protobuf-java" % "2.5.0",
@@ -44,9 +44,11 @@ javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSC
 
 parallelExecution in Test := false
 
-mergeStrategy in assembly := {
-  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-  case x => MergeStrategy.first
+assemblyMergeStrategy in assembly := {
+  case PathList("org", "apache", xs @ _*) => MergeStrategy.last
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
 }
 
 addCommandAlias("ci", ";clean ;compile ;scalastyle ;coverage ;test ;coverageReport")

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -281,7 +281,6 @@ object ErrorAggregator {
 
     val spark = SparkSession.builder()
       .appName("Error Aggregates")
-      .master("local[*]")
       .getOrCreate()
 
     opts.kafkaBroker.get match {

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -48,10 +48,20 @@ object ErrorAggregator {
       default = Some("/tmp/parquet"))
     val raiseOnError:ScallopOption[Boolean] = opt[Boolean](
       "raiseOnError",
-      descr = "Whether to program should exit on a data processing error or not.")
+      descr = "Whether the program should exit on a data processing error or not.")
     val failOnDataLoss:ScallopOption[Boolean] = opt[Boolean](
       "failOnDataLoss",
       descr = "Whether to fail the query when it’s possible that data is lost.")
+    val checkpointPath:ScallopOption[String] = opt[String](
+      "checkpointPath",
+      descr = "Checkpoint path (streaming mode only)",
+      required = false,
+      default = Some("/tmp/checkpoint"))
+    val startingOffsets:ScallopOption[String] = opt[String](
+      "startingOffsets",
+      descr = "Starting offsets (streaming mode only)",
+      required = false,
+      default = Some("latest"))
     requireOne(kafkaBroker, from)
     conflicts(kafkaBroker, List(from, to, fileLimit))
     verify()
@@ -226,7 +236,7 @@ object ErrorAggregator {
       .option("kafka.max.partition.fetch.bytes", 8 * 1024 * 1024) // 8MB
       .option("spark.streaming.kafka.consumer.cache.maxCapacity", kafkaCacheMaxCapacity)
       .option("subscribe", "telemetry")
-      .option("startingOffsets", "latest")
+      .option("startingOffsets", opts.startingOffsets())
       .load()
 
     val outputPath = opts.outputPath()
@@ -235,7 +245,7 @@ object ErrorAggregator {
       .writeStream
       .format("parquet")
       .option("path", s"${outputPath}/${outputPrefix}")
-      .option("checkpointLocation", "/tmp/checkpoint")
+      .option("checkpointLocation", opts.checkpointPath())
       .partitionBy("submission_date")
       .start()
       .awaitTermination()


### PR DESCRIPTION
These are some minimal changes needed to build a fat jar for use in the dev/prod environments. I also added some additional command-line parameters for checkpoint management.

We no longer hard-code the spark master address, so it needs to be specified to spark-submit or similar. We could fall back to `local[*]` as we do in some telemetry-batch-view jobs, but the only application over there that is using `SparkSession.builder()` is simply hard-coding `yarn` and therefore does not fall back.