### PR TITLE
Add new profile_age_days dimension

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -22,7 +22,7 @@ import org.joda.time.DateTime
 object ErrorAggregator {
 
   private val allowedDocTypes = List("main", "crash")
-  private val outputPrefix = "error_aggregates/v1"
+  private val outputPrefix = "error_aggregates/v2"
   private val kafkaCacheMaxCapacity = 1000
 
   private class Opts(args: Array[String]) extends ScallopConf(args) {
@@ -109,6 +109,7 @@ object ErrorAggregator {
     .add[String]("e10s_cohort")
     .add[String]("gfx_compositor")
     .add[Boolean]("quantum_ready")
+    .add[Int]("profile_age_days")
     .build
 
   private val metricsSchema = new SchemaBuilder()
@@ -236,6 +237,9 @@ object ErrorAggregator {
       dimensions("quantum_ready") = meta.isQuantumReady
       dimensions("experiment_id") = experiment_id
       dimensions("experiment_branch") = experiment_branch
+      dimensions("profile_age_days") = meta.`environment.profile`.flatMap(
+        _.ageDaysBin(new DateTime(meta.normalizedTimestamp().getTime))
+      )
       dimensions.build
     }
   }

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -5,6 +5,7 @@ package com.mozilla.telemetry.streaming
 
 import com.mozilla.telemetry.heka.{Message, RichMessage}
 import com.mozilla.telemetry.pings
+import org.joda.time.{DateTime, Duration}
 import org.json4s.{DefaultFormats, Extraction}
 import org.json4s.jackson.JsonMethods.{compact, render}
 
@@ -18,6 +19,8 @@ object TestUtils {
   val scalarValue = 42
   val testTimestampNano = 1460036116829920000L
   val testTimestampMillis = testTimestampNano / 1000000
+  val today = new DateTime(testTimestampMillis)
+  val todayDays = new Duration(new DateTime(0), today).getStandardDays().toInt
 
   def generateCrashMessages(size: Int, fieldsOverride: Option[Map[String, Any]]=None): Seq[Message] = {
     val defaultMap = Map(
@@ -51,11 +54,16 @@ object TestUtils {
           | "activeAddons": {"my-addon": {"isSystem": true}},
           | "theme": {"id": "firefox-compact-dark@mozilla.org"}
           |}""".stripMargin,
-        "environment.experiments" ->
-          """
-            |{
-            |  "experiment2": {"branch": "chaos"}
-            |}""".stripMargin
+      "environment.profile" ->
+        s"""
+          |{
+          | "creationDate": ${todayDays-70}
+          | }""".stripMargin,
+      "environment.experiments" ->
+        """
+          |{
+          |  "experiment2": {"branch": "chaos"}
+          |}""".stripMargin
     )
     val outputMap = fieldsOverride match {
       case Some(m) => defaultMap ++ m
@@ -101,6 +109,11 @@ object TestUtils {
           | "activeAddons": {"my-addon": {"isSystem": true}},
           | "theme": {"id": "firefox-compact-dark@mozilla.org"}
           |}""".stripMargin,
+      "environment.profile" ->
+        s"""
+           |{
+           | "creationDate": ${todayDays-70}
+           | }""".stripMargin,
       "environment.experiments" ->
         """
           |{

--- a/src/test/scala/com/mozilla/telemetry/pings/TestPings.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/TestPings.scala
@@ -7,6 +7,7 @@ import java.sql.Timestamp
 
 import org.scalatest.{FlatSpec, Matchers}
 import com.mozilla.telemetry.pings._
+import org.joda.time.{DateTime, Duration}
 
 
 class TestPings extends FlatSpec with Matchers{
@@ -148,5 +149,24 @@ class TestPings extends FlatSpec with Matchers{
   }
   "A Meta instance with e10s enabled and unknown quantumReady addons" should "be quantumReady unknown" in {
     MainPing(unknownThemeQuantumReadyPing).meta.isQuantumReady should be (None)
+  }
+
+  "A Profile instance" should "return its age in days" in {
+    val today = TestUtils.today
+    val todayDays = TestUtils.todayDays
+    // Profile with age zero
+    Profile(Some(todayDays), None).ageDays(today) should be (Some(0))
+    // Profile with positive age
+    Profile(Some(todayDays - 10), None).ageDays(today) should be (Some(10))
+    // Profile with negative age
+    Profile(Some(todayDays + 10), None).ageDays(today) should be (None)
+
+    Profile(Some(todayDays - 42), None).ageDaysBin(today) should be (Some(42))
+    Profile(Some(todayDays - 43), None).ageDaysBin(today) should be (Some(49))
+    Profile(Some(todayDays - 49), None).ageDaysBin(today) should be (Some(49))
+    Profile(Some(todayDays - 364), None).ageDaysBin(today) should be (Some(364))
+    Profile(Some(todayDays - 367), None).ageDaysBin(today) should be (Some(365))
+    Profile(Some(todayDays - 3000), None).ageDaysBin(today) should be (Some(365))
+
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -4,8 +4,11 @@
 package com.mozilla.telemetry.streaming
 
 import java.sql.Timestamp
+
 import com.mozilla.spark.sql.hyperloglog.functions.{hllCreate, hllCardinality}
+import com.mozilla.telemetry.streaming.TestUtils.todayDays
 import org.apache.spark.sql.SparkSession
+import org.joda.time.{DateTime, Duration}
 import org.json4s.DefaultFormats
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
@@ -73,7 +76,8 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
       "window_start",
       "window_end",
       "HllCardinality(client_count) as client_count",
-      "HllCardinality(long_main_input_latency_client_count) as long_main_input_latency_client_count"
+      "HllCardinality(long_main_input_latency_client_count) as long_main_input_latency_client_count",
+      "profile_age_days"
     )
 
     val query = df.selectExpr(inspectedFields:_*)
@@ -118,6 +122,7 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
     results("window_end").head.asInstanceOf[Timestamp].getTime should be >= (TestUtils.testTimestampMillis)
     results("client_count") should be (Set(1))
     results("long_main_input_latency_client_count") should be (Set(1))
+    results("profile_age_days") should be (Set(70))
   }
 
   "The aggregator" should "handle new style experiments" in {
@@ -320,5 +325,52 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
     results.getAs[Any]("long_main_input_latency_session_count") should be (5)
     results.getAs[Any]("client_count") should be (1)
     results.getAs[Any]("session_count") should be (10)
+  }
+
+  "The aggregator" should "use proper bins for profile age" in {
+    import spark.implicits._
+    val crashMessagesNewProfile = TestUtils.generateCrashMessages(
+      k,
+      Some(Map(
+        "environment.profile" ->
+        s"""
+           |{
+           | "creationDate": ${todayDays-41}
+           | }""".stripMargin
+      )))
+
+    val crashMessagesYoungProfile = TestUtils.generateCrashMessages(
+      k,
+      Some(Map(
+        "environment.profile" ->
+          s"""
+             |{
+             | "creationDate": ${todayDays-50}
+             | }""".stripMargin
+      )))
+
+    val crashMessagesOldProfile = TestUtils.generateCrashMessages(
+      k,
+      Some(Map(
+        "environment.profile" ->
+        s"""
+           |{
+           | "creationDate": ${todayDays-3000}
+           | }""".stripMargin
+      )))
+
+
+    val messages =
+      (crashMessagesNewProfile ++ crashMessagesYoungProfile ++ crashMessagesOldProfile).map(_.toByteArray).seq
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false)
+
+    // one count for each age, limited to 60
+    // multiplied by the number of experiments (chaos, control, null)
+    df.count() should be (9)
+
+    val rows = df.select("profile_age_days").collect()
+    val results = rows.map(row => row.getAs[Any]("profile_age_days")).toSet
+
+    results should be (Set(41, 56, 365))
   }
 }


### PR DESCRIPTION
This new dimension allows us to distinguish between new profiles, young
profiles, old profiles and so on. I arbitrarily decided that profiles
older than 60 days will all end up in the 60th bucket to avoid an
explosion of the number of aggregates.

I also increased the schema version as this change is not backward
compatible and it will require a data backfill.