### PR TITLE
Add client_count-based statistics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ val sparkVersion = "2.1.1"
 lazy val root = (project in file(".")).
   settings(
     libraryDependencies += "com.mozilla.telemetry" %% "moztelemetry" % "1.0-SNAPSHOT",
+    libraryDependencies += "com.mozilla.telemetry" %% "spark-hyperloglog" % "2.0.0-SNAPSHOT",
     libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test",
     libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
     libraryDependencies += "org.apache.spark" %% "spark-streaming" % sparkVersion % "provided",

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -5,11 +5,13 @@ package com.mozilla.telemetry.streaming
 
 import java.sql.{Date, Timestamp}
 
+import com.mozilla.spark.sql.hyperloglog.aggregates._
+import com.mozilla.spark.sql.hyperloglog.functions._
 import com.mozilla.telemetry.heka.{Dataset, Message}
 import com.mozilla.telemetry.pings._
 import com.mozilla.telemetry.timeseries._
 import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
-import org.apache.spark.sql.functions.{sum, window, col}
+import org.apache.spark.sql.functions.{sum, window, col, expr}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.json4s._
@@ -81,6 +83,15 @@ object ErrorAggregator {
     "CYCLE_COLLECTOR_MAX_PAUSE" -> (List("main", "content"), List(150, 250, 2500))
   )
 
+  private val clientCounts = Map(
+    "long_main_gc_or_cc_pause" -> "gc_max_pause_ms_2_main_above_150 > 0 OR cycle_collector_max_pause_main_above_150 > 0",
+    "long_content_gc_or_cc_pause" -> "gc_max_pause_ms_2_content_above_2500 > 0 OR cycle_collector_max_pause_content_above_2500 > 0",
+    "ghost_windows_main" -> "ghost_windows_main_above_1 > 0",
+    "ghost_windows_content" -> "ghost_windows_content_above_1 > 0",
+    "long_main_input_latency" -> "input_event_response_coalesced_ms_main_above_2500 > 0",
+    "long_content_input_latency" -> "input_event_response_coalesced_ms_content_above_2500 > 0"
+  )
+
   private val dimensionsSchema = new SchemaBuilder()
     .add[Timestamp]("timestamp")  // Windowed
     .add[Date]("submission_date")
@@ -113,6 +124,12 @@ object ErrorAggregator {
     .add[Int]("first_subsession_count")
     .build
 
+  // this part of the schema is used to temporarily hold
+  // data that will not be part of the final schema
+  private val tempSchema = new SchemaBuilder()
+    .add[String]("client_id")
+    .build
+
   private def thresholdHistogramName(histogramName: String, processType: String, threshold: Int): String =
     s"${histogramName.toLowerCase}_${processType}_above_${threshold}"
 
@@ -130,7 +147,10 @@ object ErrorAggregator {
     }
   }).build
 
-  private val statsSchema = SchemaBuilder.merge(metricsSchema, countHistogramErrorsSchema, thresholdHistogramsSchema)
+  private val statsSchema = SchemaBuilder.merge(metricsSchema, countHistogramErrorsSchema, thresholdHistogramsSchema, tempSchema)
+
+  private val HllMerge = new HyperLogLogMerge
+  private val FilteredHllMerge = new FilteredHyperLogLogMerge
 
   private[streaming] def aggregate(pings: DataFrame, raiseOnError: Boolean = false, online: Boolean = true): DataFrame = {
     import pings.sparkSession.implicits._
@@ -160,7 +180,9 @@ object ErrorAggregator {
 
     val stats = statsSchema.fieldNames.map(_.toLowerCase)
     val sumCols = stats.map(s => sum(s).as(s))
-
+    val countCols = clientCounts.map{
+      case (key, value) => FilteredHllMerge($"hll", expr(value)).as(s"${key}_client_count")
+    }
 
     /*
     * The resulting DataFrame will contain the grouping columns + the columns aggregated.
@@ -168,8 +190,9 @@ object ErrorAggregator {
     * */
     parsedPings
       .withColumn("window", window($"timestamp", "5 minute").as("window"))
+      .withColumn("hll", expr("HllCreate(client_id, 12)"))
       .groupBy(dimensionsCols: _*)
-      .agg(sumCols(0), sumCols.drop(1): _*)
+      .agg(HllMerge($"hll").as("client_count"), sumCols ++ countCols: _*)
       .coalesce(1)
   }
 
@@ -212,6 +235,7 @@ object ErrorAggregator {
       val dimensions = buildDimensions(ping.meta)
       val stats = new RowBuilder(statsSchema)
       stats("count") = Some(1)
+      stats("client_id") = ping.meta.clientId
       stats("main_crashes") = Some(1)
 
       dimensions.map(RowBuilder.merge(_, stats.build))
@@ -227,6 +251,7 @@ object ErrorAggregator {
       val dimensions = buildDimensions(ping.meta)
       val stats = new RowBuilder(statsSchema)
       stats("count") = Some(1)
+      stats("client_id") = ping.meta.clientId
       stats("usage_hours") = usageHours
       countHistogramErrorsSchema.fieldNames.foreach(stats_name => {
         stats(stats_name) = ping.getCountHistogramValue(stats_name)
@@ -340,6 +365,9 @@ object ErrorAggregator {
     val spark = SparkSession.builder()
       .appName("Error Aggregates")
       .getOrCreate()
+
+    spark.udf.register("HllCreate", hllCreate _)
+
 
     opts.kafkaBroker.get match {
       case Some(_) => writeStreamingAggregates(spark, opts)

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -21,6 +21,7 @@ object TestUtils {
 
   def generateCrashMessages(size: Int, fieldsOverride: Option[Map[String, Any]]=None): Seq[Message] = {
     val defaultMap = Map(
+      "clientId" -> "client1",
       "docType" -> "crash",
       "normalizedChannel" -> application.channel,
       "appName" -> application.name,
@@ -77,6 +78,7 @@ object TestUtils {
   }
   def generateMainMessages(size: Int, fieldsOverride: Option[Map[String, Any]]=None): Seq[Message] = {
     val defaultMap = Map(
+      "clientId" -> "client1",
       "docType" -> "main",
       "normalizedChannel" -> application.channel,
       "appName" -> application.name,


### PR DESCRIPTION
This change adds the ability to cheaply compute user set cardinality
using hyperloglog.
HLL is used to both count the number of distinct users for each
aggegate and to measure the impact that a certain anomaly has on users,
e.g. how many users are affected by main crashes.