### PR TITLE
Add session count-based statistics

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/package.scala
@@ -274,6 +274,14 @@ package object pings {
         case _ => None
       }
     }
+
+    def sessionId: Option[String] = {
+      this.meta.`payload.info` \ "sessionId" match {
+        case JString(v) => Some(v)
+        case _ => None
+      }
+    }
+
   }
   object MainPing {
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -114,6 +114,7 @@ object ErrorAggregator {
   private val metricsSchema = new SchemaBuilder()
     .add[Float]("usage_hours")
     .add[Int]("count")
+    .add[Int]("subsession_count")
     .add[Int]("main_crashes")
     .add[Int]("content_crashes")
     .add[Int]("gpu_crashes")
@@ -262,6 +263,7 @@ object ErrorAggregator {
       val dimensions = buildDimensions(ping.meta)
       val stats = new RowBuilder(statsSchema)
       stats("count") = Some(1)
+      stats("subsession_count") = Some(1)
       stats("client_id") = ping.meta.clientId
       stats("session_id") = ping.sessionId
       stats("usage_hours") = usageHours

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -140,7 +140,7 @@ object TestUtils {
           |  }
           |}""".stripMargin,
       "payload.simpleMeasurements" -> """{"firstPaint": 1200}""",
-      "payload.info" -> """{"subsessionLength": 3600, "subsessionCounter": 1}"""
+      "payload.info" -> """{"subsessionLength": 3600, "subsessionCounter": 1, "sessionId": "sample-session-id"}"""
     )
     val outputMap = fieldsOverride match {
       case Some(m) => defaultMap ++ m

--- a/src/test/scala/com/mozilla/telemetry/pings/TestPings.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/TestPings.scala
@@ -58,6 +58,10 @@ class TestPings extends FlatSpec with Matchers{
     subsequentPing.firstPaint should be(None)
   }
 
+  it should "return its sessionId" in {
+    mainPing.sessionId should be (Some("sample-session-id"))
+  }
+
   val recentTheme = new Theme("firefox-compact-dark@mozilla.org")
   val oldTheme = new Theme("the-oldest-theme-ever")
 

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -187,6 +187,19 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
     client_count should be (10)
   }
 
+  "The aggregator" should "correctly compute session counts" in {
+    import spark.implicits._
+    val mainMessages = 1 to 10 flatMap (i =>
+      TestUtils.generateMainMessages(
+        2, Some(Map("payload.info" -> s"""{"subsessionLength": 3600, "sessionId": "session${i%5}"}""")))
+      )
+
+    val messages = mainMessages.map(_.toByteArray).seq
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false)
+    val session_count = df.selectExpr("HllCardinality(session_count) as session_count").collect()(0).getAs[Any]("session_count")
+    session_count should be (5)
+  }
+
   "The aggregator" should "correctly compute filtered client counts" in {
     import spark.implicits._
 
@@ -236,5 +249,61 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
       "HllCardinality(long_main_input_latency_client_count) as long_main_input_latency_client_count"
     ).collect()(0).getAs[Any]("long_main_input_latency_client_count")
     client_count should be (5)
+  }
+
+  "The aggregator" should "correctly compute filtered session counts" in {
+    import spark.implicits._
+
+    val mainMessagesAffected = 1 to 5 flatMap (i =>
+      TestUtils.generateMainMessages(
+        2, Some(
+          Map(
+            "payload.info" -> s"""{"subsessionLength": 3600, "sessionId": "session${i}"}""",
+            "payload.histograms" ->
+              """{
+                |  "INPUT_EVENT_RESPONSE_COALESCED_MS": {
+                |    "values": {
+                |      "1": 1,
+                |      "150": 2,
+                |      "250": 3,
+                |      "2500": 4,
+                |      "10000": 5
+                |    }
+                |  }
+                |}""".stripMargin
+          )))
+      )
+
+    val mainMessagesNotAffected = 6 to 10 flatMap (i =>
+      TestUtils.generateMainMessages(
+        2, Some(
+          Map(
+            "payload.info" -> s"""{"subsessionLength": 3600, "sessionId": "session${i}"}""",
+            "payload.histograms" ->
+              """{
+                |  "INPUT_EVENT_RESPONSE_COALESCED_MS": {
+                |    "values": {
+                |      "1": 1,
+                |      "150": 2,
+                |      "250": 3,
+                |      "2500": 0,
+                |      "10000": 0
+                |    }
+                |  }
+                |}""".stripMargin
+          )))
+      )
+
+    val messages = (mainMessagesAffected ++ mainMessagesNotAffected).map(_.toByteArray).seq
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false)
+
+    val results = df.selectExpr(
+      "HllCardinality(long_main_input_latency_session_count) as long_main_input_latency_session_count",
+      "HllCardinality(client_count) as client_count",
+      "HllCardinality(session_count) as session_count"
+    ).collect()(0)
+    results.getAs[Any]("long_main_input_latency_session_count") should be (5)
+    results.getAs[Any]("client_count") should be (1)
+    results.getAs[Any]("session_count") should be (10)
   }
 }


### PR DESCRIPTION
Same as 8687e8e6b861f50f178bfa841bea64b09b00cd36, but this time for
session counts. I added client_id to the recipe for the session hll
to mitigate the risk of collisions.