### PR TITLE
Normalize os_version in error_aggregates

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/package.scala
@@ -32,7 +32,9 @@ package object pings {
       version: String,
       xpcomAbi: String)
 
-  case class SystemOs(name: String, version: String)
+  case class SystemOs(name: String, version: String) {
+    def normalizedVersion: String = OS(Option(name), Option(version)).normalizedVersion
+  }
 
   case class SystemGfxFeatures(compositor: Option[String])
 
@@ -342,7 +344,18 @@ package object pings {
 
   case class EnvironmentSystem(os: OS)
 
-  case class OS(name: Option[String], version: Option[String])
+  case class OS(name: Option[String], version: Option[String]){
+    val versionRegex = "(\\d+(\\.\\d+)?(\\.\\d+)?)?.*".r
+    def normalizedVersion: String = {
+      version match {
+        case Some(v) =>
+          val versionRegex(normalized, b, c) = v
+          normalized
+        case None =>
+          null
+      }
+    }
+  }
 
   def messageToPing(message: Message, jsonFieldNames: List[String]): JValue = {
     implicit val formats = DefaultFormats

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -210,7 +210,7 @@ object ErrorAggregator {
       dimensions("build_id") = meta.`environment.build`.flatMap(_.buildId)
       dimensions("application") = Some(meta.appName)
       dimensions("os_name") = meta.`environment.system`.map(_.os.name)
-      dimensions("os_version") = meta.`environment.system`.map(_.os.version)
+      dimensions("os_version") = meta.`environment.system`.map(_.os.normalizedVersion)
       dimensions("architecture") = meta.`environment.build`.flatMap(_.architecture)
       dimensions("country") = Some(meta.geoCountry)
       dimensions("e10s_enabled") = meta.`environment.settings`.flatMap(_.e10sEnabled)

--- a/src/test/scala/com/mozilla/telemetry/pings/TestPings.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/TestPings.scala
@@ -20,20 +20,24 @@ class TestPings extends FlatSpec with Matchers{
     mainPing.getCountHistogramValue("foo").isEmpty should be (true)
     mainPing.getCountHistogramValue("BROWSER_SHIM_USAGE_BLOCKED").get should be (1)
   }
+
   it should "return the value of a keyed count histogram" in {
     mainPing.getCountKeyedHistogramValue("foo", "bar").isEmpty should be (true)
     mainPing.getCountKeyedHistogramValue("SUBPROCESS_CRASHES_WITH_DUMP", "foo").isEmpty should be (true)
     mainPing.getCountKeyedHistogramValue("SUBPROCESS_CRASHES_WITH_DUMP", "content").get should be (1)
   }
+
   it should "return the value of its usage hours" in {
     mainPing.usageHours.get should be (1.0)
     val messageNoUsageHours = TestUtils.generateMainMessages(1, Some(Map("payload.info" -> "{}"))).head
     val pingNoUsageHours = MainPing(messageNoUsageHours)
     pingNoUsageHours.usageHours.isEmpty should be (true)
   }
+
   it should "return its timestamp" in {
     mainPing.meta.normalizedTimestamp() should be (new Timestamp(ts))
   }
+
   it should "return the right threshold count" in {
     mainPing.histogramThresholdCount("INPUT_EVENT_RESPONSE_COALESCED_MS", 150, "main") should be (14)
     mainPing.histogramThresholdCount("INPUT_EVENT_RESPONSE_COALESCED_MS", 250, "main") should be (12)
@@ -43,6 +47,7 @@ class TestPings extends FlatSpec with Matchers{
     mainPing.histogramThresholdCount("INPUT_EVENT_RESPONSE_COALESCED_MS", 250, "content") should be (3)
     mainPing.histogramThresholdCount("INPUT_EVENT_RESPONSE_COALESCED_MS", 2500, "content") should be (2)
   }
+
   it should "return its firstPaint value" in {
     mainPing.firstPaint should be (Some(1200))
   }
@@ -147,6 +152,7 @@ class TestPings extends FlatSpec with Matchers{
   "A Meta instance with e10s enabled and quantumReady addons" should "be quantumReady" in {
     MainPing(quantumReadyPing).meta.isQuantumReady should be (Some(true))
   }
+
   "A Meta instance with e10s enabled and unknown quantumReady addons" should "be quantumReady unknown" in {
     MainPing(unknownThemeQuantumReadyPing).meta.isQuantumReady should be (None)
   }
@@ -167,6 +173,18 @@ class TestPings extends FlatSpec with Matchers{
     Profile(Some(todayDays - 364), None).ageDaysBin(today) should be (Some(364))
     Profile(Some(todayDays - 367), None).ageDaysBin(today) should be (Some(365))
     Profile(Some(todayDays - 3000), None).ageDaysBin(today) should be (Some(365))
+  }
 
+  "An OS instance" should "normalize the version" in {
+    OS(Some("linux"), Some("1.1.1-ignore")).normalizedVersion should be ("1.1.1")
+    OS(Some("linux"), Some("1.1.1ignore")).normalizedVersion should be ("1.1.1")
+    OS(Some("linux"), Some("1.1")).normalizedVersion should be ("1.1")
+    OS(Some("linux"), Some("1.1-ignore")).normalizedVersion should be ("1.1")
+    OS(Some("linux"), Some("1.1ignore")).normalizedVersion should be ("1.1")
+    OS(Some("linux"), Some("1")).normalizedVersion should be ("1")
+    OS(Some("linux"), Some("1-ignore")).normalizedVersion should be ("1")
+    OS(Some("linux"), Some("1ignore")).normalizedVersion should be ("1")
+    OS(Some("linux"), Some("non-numeric")).normalizedVersion should be (null)
+    OS(Some("linux"), Some("nonnumeric1.1")).normalizedVersion should be (null)
   }
 }


### PR DESCRIPTION
We see over 9000 different os_versions a day. We really don't care
about all of those, so this will normalize them: e.g. instead of
"1.1.1-special-build", it will just get "1.1.1".

Fixes #75 