### PR TITLE
Limit build ids to the last 6 months

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/package.scala
@@ -34,7 +34,7 @@ package object pings {
       xpcomAbi: String)
 
   case class SystemOs(name: String, version: String) {
-    def normalizedVersion: String = OS(Option(name), Option(version)).normalizedVersion
+    val normalizedVersion: String = OS(Option(name), Option(version)).normalizedVersion
   }
 
   case class SystemGfxFeatures(compositor: Option[String])
@@ -162,7 +162,7 @@ package object pings {
       new Timestamp(this.Timestamp / 1000000)
     }
 
-    def normalizedBuildId(): Option[String] = {
+    val normalizedBuildId: Option[String] = {
       `environment.build`.flatMap(_.buildId) match {
         case Some(buildId: String) => {
           val buildIdDay = buildId.slice(0, 8).toString()
@@ -365,7 +365,7 @@ package object pings {
 
   case class OS(name: Option[String], version: Option[String]){
     val versionRegex = "(\\d+(\\.\\d+)?(\\.\\d+)?)?.*".r
-    def normalizedVersion: String = {
+    val normalizedVersion: String = {
       version match {
         case Some(v) =>
           val versionRegex(normalized, b, c) = v

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -207,7 +207,7 @@ object ErrorAggregator {
       dimensions("submission_date") = Some(new Date(meta.normalizedTimestamp().getTime))
       dimensions("channel") = Some(meta.normalizedChannel)
       dimensions("version") = meta.`environment.build`.flatMap(_.version)
-      dimensions("build_id") = meta.`environment.build`.flatMap(_.buildId)
+      dimensions("build_id") = meta.normalizedBuildId()
       dimensions("application") = Some(meta.appName)
       dimensions("os_name") = meta.`environment.system`.map(_.os.name)
       dimensions("os_version") = meta.`environment.system`.map(_.os.normalizedVersion)

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -207,7 +207,7 @@ object ErrorAggregator {
       dimensions("submission_date") = Some(new Date(meta.normalizedTimestamp().getTime))
       dimensions("channel") = Some(meta.normalizedChannel)
       dimensions("version") = meta.`environment.build`.flatMap(_.version)
-      dimensions("build_id") = meta.normalizedBuildId()
+      dimensions("build_id") = meta.normalizedBuildId
       dimensions("application") = Some(meta.appName)
       dimensions("os_name") = meta.`environment.system`.map(_.os.name)
       dimensions("os_version") = meta.`environment.system`.map(_.os.normalizedVersion)

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -176,8 +176,6 @@ class TestErrorAggregator extends AsyncFlatSpec with Matchers with BeforeAndAfte
         ++ TestUtils.generateMainMessages(k, fieldsOverride=fieldsOverride)).map(_.toByteArray).seq
     val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false)
 
-    println(TestUtils.generateCrashMessages(1, fieldsOverride=fieldsOverride))
-
     // 1 for each experiment (there are 2), and one for a null experiment
     df.count() should be (3)
     val inspectedFields = List(


### PR DESCRIPTION
This will reduce the number of aggregates we generate, which should
speed up aggregation and reduce the size of the output parquet file.