### PR TITLE
Add displayVersion to error aggregates table

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/package.scala
@@ -21,6 +21,7 @@ package object pings {
       platformVersion: String,
       vendor: String,
       version: String,
+      displayVersion: String,
       xpcomAbi: String)
 
   case class Build(

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -13,7 +13,7 @@ import org.json4s.jackson.JsonMethods.{compact, render}
 object TestUtils {
   implicit val formats = DefaultFormats
   val application = pings.Application(
-    "x86", "20170101000000", "release", "Firefox", "42.0", "Mozilla", "42.0", "x86-msvc"
+    "x86", "20170101000000", "release", "Firefox", "42.0", "Mozilla", "42.0", "42.0b1", "x86-msvc"
   )
   private val applicationJson = compact(render(Extraction.decompose(application)))
   val scalarValue = 42
@@ -29,6 +29,7 @@ object TestUtils {
       "normalizedChannel" -> application.channel,
       "appName" -> application.name,
       "appVersion" -> application.version.toDouble,
+      "displayVersion" -> application.displayVersion,
       "appBuildId" -> application.buildId,
       "geoCountry" -> "IT",
       "os" -> "Linux",
@@ -92,6 +93,7 @@ object TestUtils {
       "normalizedChannel" -> application.channel,
       "appName" -> application.name,
       "appVersion" -> application.version.toDouble,
+      "displayVersion" -> application.displayVersion,
       "appBuildId" -> application.buildId,
       "geoCountry" -> "IT",
       "os" -> "Linux",

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -89,6 +89,7 @@ class TestErrorAggregator extends AsyncFlatSpec with Matchers with BeforeAndAfte
       "submission_date",
       "channel",
       "version",
+      "display_version",
       "build_id",
       "application",
       "os_name",
@@ -133,6 +134,7 @@ class TestErrorAggregator extends AsyncFlatSpec with Matchers with BeforeAndAfte
     results("submission_date").map(_.toString) should be (Set("2016-04-07"))
     results("channel") should be (Set(app.channel))
     results("version") should be (Set(app.version))
+    results("display_version") should be (Set(app.displayVersion))
     results("build_id") should be (Set(app.buildId))
     results("application") should be (Set(app.name))
     results("os_name") should be (Set("Linux"))


### PR DESCRIPTION
This column will give more precise versioning information (e.g. 47.0b1 as
opposed to just 47.0). It should not increase the cardinality of the dataset,
as there should be a 1:1 mapping between it and buildId.