### PR TITLE
Docs - README.md - Capitalizing Title

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Spark Streaming ETL jobs for Mozilla Telemetry
 
 ---
 
+<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4"></img>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/mozilla/telemetry-streaming.svg?branch=master)](https://travis-ci.org/mozilla/telemetry-streaming)
 [![codecov.io](https://codecov.io/github/mozilla/telemetry-streaming/coverage.svg?branch=master)](https://codecov.io/github/mozilla/telemetry-streaming?branch=master)
 
-# telemetry-streaming
+# Telemetry Streaming
+
 Spark Streaming ETL jobs for Mozilla Telemetry

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@
 # Telemetry Streaming
 
 Spark Streaming ETL jobs for Mozilla Telemetry
+
+---
+

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Spark Streaming ETL jobs for Mozilla Telemetry
 
 ---
 
-<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4"></img>
+<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4" width="50"></img>


### PR DESCRIPTION
## Docs - README.md - Capitalizing Title

**this PR does basically aim at**:
- capitalizing title in readme.md
- adding separators to readme.md
- adding mozilla logo to readme.md