### PR TITLE
[Bug 1375018] telemetry-streaming add maven local repo to replace sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import sys.process._;
 
+val localMavenHttps = "https://s3-us-west-2.amazonaws.com/net-mozaws-data-us-west-2-ops-mavenrepo/"
+
 resolvers ++= Seq(
   "Conjars" at "http://conjars.org/repo",
   "Artima Maven Repository" at "http://repo.artima.com/releases",
-  "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+  "S3 local maven snapshots" at localMavenHttps + "snapshots"
 )
 
 name := "telemetry-streaming"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("com.artima.supersafe" % "sbtplugin" % "1.1.2")
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.27")
 
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
+
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.12.0")


### PR DESCRIPTION
- Moztelemetry add maven local repo to replace sonatype
- Add circleci build to automatically publish jar to local maven repo on commits to master (this will require extra setup on the github side)