### PR TITLE
Backport displayVersion schema addition

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/package.scala
@@ -19,6 +19,7 @@ package object pings {
       platformVersion: String,
       vendor: String,
       version: String,
+      displayVersion: Option[String],
       xpcomAbi: String)
 
   case class Build(

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -86,6 +86,7 @@ object ErrorAggregator {
     .add[Date]("submission_date")
     .add[String]("channel")
     .add[String]("version")
+    .add[String]("display_version")
     .add[String]("build_id")
     .add[String]("application")
     .add[String]("os_name")
@@ -170,12 +171,13 @@ object ErrorAggregator {
       .withColumn("window_end", $"window.end")
       .drop("window")
   }
-  private def buildDimensions(meta: Meta): Row = {
+  private def buildDimensions(meta: Meta, application: Application): Row = {
     val dimensions = new RowBuilder(dimensionsSchema)
     dimensions("timestamp") = Some(meta.normalizedTimestamp())
     dimensions("submission_date") = Some(new Date(meta.normalizedTimestamp().getTime))
     dimensions("channel") = Some(meta.normalizedChannel)
     dimensions("version") = meta.`environment.build`.flatMap(_.version)
+    dimensions("display_version") = application.displayVersion
     dimensions("build_id") = meta.`environment.build`.flatMap(_.buildId)
     dimensions("application") = Some(meta.appName)
     dimensions("os_name") = meta.`environment.system`.map(_.os.name)
@@ -202,7 +204,7 @@ object ErrorAggregator {
     def parse(): Array[Row] = {
       // Non-main crashes are already retrieved from main pings
       if(!ping.isMainCrash) throw new Exception("Only Crash pings of type `main` are allowed")
-      val dimensions = buildDimensions(ping.meta)
+      val dimensions = buildDimensions(ping.meta, ping.application)
       val stats = new RowBuilder(statsSchema)
       stats("count") = Some(1)
       stats("main_crashes") = Some(1)
@@ -217,7 +219,7 @@ object ErrorAggregator {
       val usageHours = ping.usageHours
       if (usageHours.isEmpty) throw new Exception("Main pings should have a  number of usage hours != 0")
 
-      val dimensions = buildDimensions(ping.meta)
+      val dimensions = buildDimensions(ping.meta, ping.application)
       val stats = new RowBuilder(statsSchema)
       stats("count") = Some(1)
       stats("usage_hours") = usageHours

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestUtils.scala
@@ -5,14 +5,14 @@ package com.mozilla.telemetry.streaming
 
 import com.mozilla.telemetry.heka.{Message, RichMessage}
 import com.mozilla.telemetry.pings
-import org.json4s.{DefaultFormats, Extraction}
+import org.json4s.{DefaultFormats, Extraction, JField}
 import org.json4s.jackson.JsonMethods.{compact, render}
 
 
 object TestUtils {
   implicit val formats = DefaultFormats
   val application = pings.Application(
-    "x86", "20170101000000", "release", "Firefox", "42.0", "Mozilla", "42.0", "x86-msvc"
+    "x86", "20170101000000", "release", "Firefox", "42.0", "Mozilla", "42.0", Some("42.0b1"), "x86-msvc"
   )
   private val applicationJson = compact(render(Extraction.decompose(application)))
   val scalarValue = 42
@@ -25,6 +25,7 @@ object TestUtils {
       "normalizedChannel" -> application.channel,
       "appName" -> application.name,
       "appVersion" -> application.version.toDouble,
+      "displayVersion" -> application.displayVersion.getOrElse(null),
       "appBuildId" -> application.buildId,
       "geoCountry" -> "IT",
       "os" -> "Linux",
@@ -51,6 +52,7 @@ object TestUtils {
           | "theme": {"id": "firefox-compact-dark@mozilla.org"}
           |}""".stripMargin
     )
+    val applicationJson = compact(render(Extraction.decompose(application)))
     val outputMap = fieldsOverride match {
       case Some(m) => defaultMap ++ m
       case _ => defaultMap
@@ -70,12 +72,14 @@ object TestUtils {
       )
     }
   }
-  def generateMainMessages(size: Int, fieldsOverride: Option[Map[String, Any]]=None): Seq[Message] = {
+  def generateMainMessages(size: Int, fieldsOverride: Option[Map[String, Any]]=None,
+                           fieldsToRemove: List[String] = List[String]()): Seq[Message] = {
     val defaultMap = Map(
       "docType" -> "main",
       "normalizedChannel" -> application.channel,
       "appName" -> application.name,
       "appVersion" -> application.version.toDouble,
+      "displayVersion" -> application.displayVersion.getOrElse(null),
       "appBuildId" -> application.buildId,
       "geoCountry" -> "IT",
       "os" -> "Linux",
@@ -134,6 +138,12 @@ object TestUtils {
       case Some(m) => defaultMap ++ m
       case _ => defaultMap
     }
+
+    val applicationData = Extraction.decompose(application) removeField {
+      case JField(x, _) if fieldsToRemove.contains(x) => true
+      case _ => false
+    }
+    val applicationJson = compact(render(applicationData))
     1.to(size) map { index =>
       RichMessage(s"main-${index}",
         outputMap,


### PR DESCRIPTION
This is the "v1" branch with the code to add a displayVersion column backported. Hopefully we can deploy this successfully while waiting for a solution that allows us to deploy the rest of the functionality in the master branch, since it unblocks a pretty important relman use case -- using mission control to monitor beta rollouts.