### PR TITLE
Refactor tests to conform with Scalastyle rules, enable Scalastyle in test scope on CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,4 +78,4 @@ assemblyMergeStrategy in assembly := {
     oldStrategy(x)
 }
 
-addCommandAlias("ci", ";clean ;compile ;scalastyle ;coverage ;dockerComposeTest ;coverageReport")
+addCommandAlias("ci", ";clean ;compile ;scalastyle ;test:scalastyle ;coverage ;dockerComposeTest ;coverageReport")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -61,7 +61,7 @@
  <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+ <check customId="print-ln" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[println]]></parameter>
   </parameters>
@@ -84,12 +84,12 @@
    <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
   </parameters>
  </check>
- <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+ <check customId="methodLength" level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxLength"><![CDATA[100]]></parameter>
   </parameters>
  </check>
- <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+ <check customId="methodName" level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
   </parameters>

--- a/src/test/scala/com/mozilla/telemetry/Kafka.scala
+++ b/src/test/scala/com/mozilla/telemetry/Kafka.scala
@@ -1,6 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 package com.mozilla.telemetry.streaming
 
 import java.util.Properties
+
 import kafka.admin.AdminUtils
 import kafka.utils.ZkUtils
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
@@ -18,10 +22,10 @@ object Kafka {
     // taken from
     // https://github.com/apache/spark/blob/master/external/kafka-0-10-sql +
     // src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala#L350
-    return zkUtils.getAllTopics().contains(topic)
+    zkUtils.getAllTopics().contains(topic)
   }
 
-  def createTopic(topic: String, numPartitions: Int = kafkaTopicPartitions) = {
+  def createTopic(topic: String, numPartitions: Int = kafkaTopicPartitions): Unit = {
     val timeoutMs = 10000
     val isSecureKafkaCluster = false
     val replicationFactor = 1
@@ -46,7 +50,7 @@ object Kafka {
     def send(message: Array[Byte], synchronous: Boolean = false): Unit = {
       val record = new ProducerRecord[String, Array[Byte]](topic, message)
       kafkaProducer.send(record)
-      if(synchronous) { 
+      if (synchronous) {
         kafkaProducer.flush()
       }
     }

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -86,6 +86,7 @@ object TestUtils {
     }
   }
 
+  // scalastyle:off methodLength
   def generateMainMessages(size: Int, fieldsOverride: Option[Map[String, Any]]=None, timestamp: Option[Long]=None,
                            fieldsToRemove: List[String] = List[String]()): Seq[Message] = {
     val defaultMap = Map(
@@ -195,6 +196,7 @@ object TestUtils {
       )
     }
   }
+  // scalastyle:on methodLength
 
   def generateFocusEventMessages(size: Int, fieldsOverride: Option[Map[String, Any]]=None, timestamp: Option[Long]=None): Seq[Message] = {
     val defaultMap = Map(

--- a/src/test/scala/com/mozilla/telemetry/pings/TestFocusEventPing.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/TestFocusEventPing.scala
@@ -1,3 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 package com.mozilla.telemetry.streaming
 
 import org.scalatest.{FlatSpec, Matchers}

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -48,7 +48,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
         ++ TestUtils.generateMainMessages(k)).map(_.toByteArray).seq
 
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -146,7 +146,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
       (TestUtils.generateCrashMessages(k, fieldsOverride=fieldsOverride)
         ++ TestUtils.generateMainMessages(k, fieldsOverride=fieldsOverride)).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -200,7 +200,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
       )))
     val messages = (crashMessage ++ mainMessage).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -234,7 +234,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
 
     val messages = (crashMessages ++ mainMessages).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -252,7 +252,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
 
     val messages = mainMessages.map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -297,7 +297,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
     val messages =
       (crashMessagesNewProfile ++ crashMessagesYoungProfile ++ crashMessagesOldProfile).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -322,7 +322,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
     val messages =
       (fxCrashMessage ++ fxMainMessage ++ otherCrashMessage ++ otherMainMessage).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -384,11 +384,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
         }
       }
 
-      override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
-        if(messagesSeen < expectedTotalMsgs){
-          println(s"Terminated Early: Expected $expectedTotalMsgs messages, saw $messagesSeen")
-        }
-      }
+      override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = ()
     }
 
     spark.streams.addListener(listener)
@@ -411,7 +407,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
     import spark.implicits._
     val messages = TestUtils.generateCrashMessages(10).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -429,7 +425,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
       )
     ).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -444,7 +440,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
       )
     ).map(_.toByteArray).seq
 
-    val df2 = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false, 
+    val df2 = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)
@@ -458,7 +454,7 @@ class TestErrorAggregator extends FlatSpec with Matchers {
       1, None, None, "displayVersion" :: Nil
     ).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = false, online = false,
       ErrorAggregator.defaultDimensionsSchema, ErrorAggregator.defaultMetricsSchema,
       ErrorAggregator.defaultCountHistogramErrorsSchema,
       ErrorAggregator.defaultThresholdHistograms)

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestEventsToAmplitude.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestEventsToAmplitude.scala
@@ -92,6 +92,7 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
   override def afterEach {
     verify(expectedTotalMsgs,
       requestMadeFor(new ValueMatcher[Request] {
+        // scalastyle:off methodName
         def `match`(request: Request): MatchResult = {
           val events = URLDecoder.decode(request.queryParameter("event").values.head, "UTF-8")
           MatchResult.of(
@@ -103,20 +104,21 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
               .isExactMatch()
           )
         }
+        // scalastyle:on methodName
       })
     )
 
     wireMockServer.stop()
   }
 
-  def ConfigFilePath: String = {
+  private def configFilePath: String = {
     getClass.getResource(ConfigFileName).getPath
   }
 
   def encode(in: String): String = URLEncoder.encode(in, "UTF-8")
 
   "HTTPSink" should "send events correctly" in {
-    val config = EventsToAmplitude.readConfigFile(ConfigFilePath)
+    val config = EventsToAmplitude.readConfigFile(configFilePath)
     val msgs = TestUtils.generateFocusEventMessages(expectedTotalMsgs)
     val sink = new sinks.HttpSink(s"http://$Host:$Port$path", Map("api_key" -> apiKey))
 
@@ -163,11 +165,11 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
 
     spark.streams.addListener(listener)
 
-    val args = 
+    val args =
       "--kafka-broker"     :: Kafka.kafkaBrokers            ::
       "--starting-offsets" :: "latest"                      ::
       "--url"              :: s"http://$Host:$Port$path"    ::
-      "--config-file-path" :: ConfigFilePath                ::
+      "--config-file-path" :: configFilePath                ::
       "--raise-on-error"   :: Nil
 
     EventsToAmplitude.main(args.toArray)

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
@@ -43,7 +43,7 @@ class TestExperimentsErrorAggregator extends FlatSpec with Matchers {
     val messages = (TestUtils.generateCrashMessages(k)
         ++ TestUtils.generateMainMessages(k)).map(_.toByteArray).seq
 
-    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false, 
+    val df = ErrorAggregator.aggregate(spark.sqlContext.createDataset(messages).toDF, raiseOnError = true, online = false,
       ExperimentsErrorAggregator.defaultDimensionsSchema, ExperimentsErrorAggregator.defaultMetricsSchema,
       ExperimentsErrorAggregator.defaultCountHistogramErrorsSchema,
       ExperimentsErrorAggregator.defaultThresholdHistograms)


### PR DESCRIPTION
This enables Scalastyle checks for tests. Also, some small refactors were needed so all tests conform to the rules.