### PR TITLE
Bug 1423340 - Make tests easily runnable from IDE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ scala:
 env:
   - DOCKER_DIR="../docker/"
 script:
-  - ./runtests.sh ci
+  - sbt ci
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ the source code and running the tests via sbt. Some common invocations for sbt:
 * `sbt dockerComposeTest  # run the docker compose tests (slow)`
 * `sbt "dockerComposeTest -tags:DockerComposeTag" # run only tests with DockerComposeTag (while using docker)`
 * `sbt ci  # run all tests`
+
+Some tests need Kafka to run. If one prefers to run them via IDE, it's required to run the test cluster:
+```bash
+sbt dockerComposeUp
+```
+or via plain docker-compose:
+```bash
+export DOCKER_KAFKA_HOST=$(./docker_setup.sh)
+docker-compose -f docker/docker-compose.yml up
+```
+It's also good to shut down the cluster afterwards:
+```bash
+sbt dockerComposeStop
+```

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -1,11 +1,13 @@
-rm -rf /tmp/checkpoint /tmp/parquet
 EN=$(ifconfig en0 | grep "inet " | grep -oE '([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)' | head -n 1)
 ETH=$(ifconfig eth0 | grep "inet " | grep -oE '([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)' | head -n 1)
+INTERNAL_IP=$(ip route get 8.8.8.8 | awk '{print $NF; exit}')
 
-if test -z "$EN"; then
+if test -n "$EN"; then
+    DOCKER_KAFKA_HOST=$EN
+elif test -n "$ETH"; then
     DOCKER_KAFKA_HOST=$ETH
 else
-    DOCKER_KAFKA_HOST=$EN
+    DOCKER_KAFKA_HOST=$INTERNAL_IP
 fi
 
 echo $DOCKER_KAFKA_HOST

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,2 +1,0 @@
-export AMPLITUDE_API_KEY="test-api-key"
-sbt "$@"


### PR DESCRIPTION
Previously it wasn't simple to easily and repeatedly execute tests from IDE.
From now on:
* tests are responsible for cleaning up their state (previously it was docker setup script's job)
* generic option for discovering internal IP address is added in docker setup script (useful when one's interface names don't match those listed in script)