### PR TITLE
Make HTTP sink more resilient to errors

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/sinks/HTTPSink.scala
+++ b/src/main/scala/com/mozilla/telemetry/sinks/HTTPSink.scala
@@ -5,8 +5,24 @@ package com.mozilla.telemetry.streaming.sinks
 
 import scalaj.http.{Http, HttpRequest}
 import org.apache.spark.sql.ForeachWriter
+import scala.annotation.tailrec
+import scala.util.{Try, Success, Failure}
 
-class HttpSink[String](url: String, parameters: Map[String, String]) extends ForeachWriter[String] {
+class HttpSink[String](url: String, parameters: Map[String, String], maxAttempts: Int = 5, defaultDelay: Int = 500, connectionTimeout: Int = 2000)
+  extends ForeachWriter[String] {
+
+  // codes to retry a request on - allow retries on timeouts
+  // docs: https://amplitude.zendesk.com/hc/en-us/articles/204771828#http-status-codes-retrying-failed-requests
+
+  val TimeoutPseudoCode = -1
+  val RetryCodes = TimeoutPseudoCode :: 429 :: 500 :: 502 :: 503 :: 504 :: Nil
+  val OK = 200
+
+  // timeouts in ms
+  val ReadTimeout = 5000
+
+  @transient lazy val log = org.apache.log4j.LogManager.getLogger("HttpSinkLogger")
+
   def close(errorOrNull: Throwable): Unit = {}
   def open(partitionId: Long,version: Long): Boolean = true
 
@@ -17,8 +33,32 @@ class HttpSink[String](url: String, parameters: Map[String, String]) extends For
   }
 
   def process(event: String): Unit = {
-    getRequest
-      .param("event", event.toString)
-      .asString
+    attempt(
+      getRequest
+        .param("event", event.toString)
+        .timeout(connTimeoutMs = connectionTimeout, readTimeoutMs = ReadTimeout))
+  }
+
+  private def backoff(tries: Int): Long = (scala.math.pow(2, tries) - 1).toLong * defaultDelay
+
+  @tailrec
+  private def attempt(request: HttpRequest, tries: Int = 0): Unit = {
+    if(tries > 0) { // minor optimization
+      java.lang.Thread.sleep(backoff(tries))
+    }
+
+    val code = Try(request.asString.code) match {
+      case Success(c) => c
+      case Failure(e: java.net.SocketTimeoutException) => TimeoutPseudoCode
+    }
+
+    (code, tries == maxAttempts) match {
+      case (OK, _) =>
+      case (c, false) if RetryCodes.contains(c)=> attempt(request, tries + 1)
+      case (c, _) => {
+        val url = request.url + "?" + request.params.map{ case(k, v) => s"k=v" }.mkString("&")
+        log.warn(s"Failed request $url, last status code: $c")
+      }
+    }
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/sinks/TestHTTPSink.scala
+++ b/src/test/scala/com/mozilla/telemetry/sinks/TestHTTPSink.scala
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package com.mozilla.telemetry.streaming
+
+import com.mozilla.telemetry.streaming.sinks.HttpSink
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
+import org.scalatest._
+import scala.annotation.tailrec
+
+class TestHTTPSink extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+  val Port = 9876
+  val Host = "localhost"
+  val Path = "/httpapi"
+
+  var wireMockServer: WireMockServer = _
+
+  val maxAttempts = 5
+  val delay = 1
+  val timeout = 100
+
+  val httpSink = new HttpSink(s"http://$Host:$Port$Path", Map.empty, maxAttempts, delay, timeout)
+
+  var scenario = "Response Codes Scenario"
+  var event = """{"event": "test event, please ignore"}"""
+
+  val pathMatch = Path + "\\?.*"
+
+  val OK = 200
+  val BAD_REQUEST = 400
+  val SERVER_ERROR = 503
+  val UNKNOWN = 666
+
+  override def beforeEach {
+    wireMockServer = new WireMockServer(wireMockConfig().port(Port))
+    wireMockServer.start()
+    WireMock.configureFor(Host, Port)
+  }
+
+  override def afterEach {
+    wireMockServer.stop()
+  }
+
+  @tailrec
+  private def multiStub(responseCodes: Seq[Int], scenarioState: String = STARTED): Unit = {
+    val nextScenario = "post" + scenarioState
+
+    stubFor(get(urlMatching(pathMatch))
+      .inScenario(scenario)
+      .whenScenarioStateIs(scenarioState)
+      .willReturn(aResponse().withStatus(responseCodes.head))
+      .willSetStateTo(nextScenario))
+
+    if(!responseCodes.tail.isEmpty) {
+      multiStub(responseCodes.tail, nextScenario)
+    }
+  }
+
+  private def verifyCount(count: Int): Unit = {
+    verify(count, getRequestedFor(urlMatching(pathMatch)))
+  }
+
+  "HTTP Sink" should "only send once on success" in {
+    val responseCodes = OK :: Nil
+
+    multiStub(responseCodes)
+    httpSink.process(event)
+    verifyCount(responseCodes.size)
+  }
+
+  it should "keep attempting on failure" in {
+    val responseCodes = SERVER_ERROR :: SERVER_ERROR :: SERVER_ERROR :: OK :: Nil
+
+    multiStub(responseCodes)
+    httpSink.process(event)
+    verifyCount(responseCodes.size)
+  }
+
+  it should "stop attempting after too many failures" in {
+    val responseCodes = List.fill(maxAttempts)(SERVER_ERROR) :+ OK
+
+    multiStub(responseCodes)
+    httpSink.process(event)
+    verifyCount(responseCodes.size)
+  }
+
+  it should "retry after timeout" in {
+    val scenario = "retry after timeout"
+
+    stubFor(get(urlMatching(pathMatch))
+      .inScenario(scenario)
+      .whenScenarioStateIs(STARTED)
+      .willSetStateTo("nowait")
+      .willReturn(aResponse()
+        .withStatus(BAD_REQUEST)
+        .withFixedDelay(timeout + 10)))
+
+    stubFor(get(urlMatching(pathMatch))
+      .inScenario(scenario)
+      .whenScenarioStateIs("nowait")
+      .willReturn(aResponse()
+        .withStatus(OK)))
+
+    httpSink.process(event)
+    verifyCount(1) // only the success
+  }
+
+  it should "not retry on unknown codes" in {
+    val responseCodes = UNKNOWN :: Nil
+
+    multiStub(responseCodes)
+    httpSink.process(event)
+    verifyCount(1)
+  }
+}


### PR DESCRIPTION
This handles:
- Retrying after timeouts
- Retrying after server errors
- Logging on failures

docs here on response codes: https://amplitude.zendesk.com/hc/en-us/articles/204771828#http-status-codes-retrying-failed-requests

Note that this change does not include dealing with too-large payloads (response 413) since at this point we're nowhere near that number for any payload. Bug 1449092 will handle that.