### PR TITLE
Use repartition instead of coalesce in streaming job

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -202,7 +202,6 @@ object ErrorAggregator {
       .groupBy(dimensionsCols: _*)
       .agg(aggCols.head, aggCols.tail: _*)
       .drop("window")
-      .coalesce(1)
   }
 
   private def buildDimensions(dimensionsSchema: StructType, meta: Meta, application: Application): Array[Row] = {


### PR DESCRIPTION
Coalescing to 1 partition constrains all aggregations to one node, which eventually causes OOMs on production workloads.