### PR TITLE
Bug 1434378 - Track startup crashes

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/package.scala
@@ -3,18 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
-import scala.util.{Success, Try}
 import java.sql.Timestamp
 
 import com.mozilla.telemetry.heka.Message
-import org.joda.time.{DateTime, Duration, Months}
 import org.joda.time.format.DateTimeFormat
-
-
-import org.json4s._
+import org.joda.time.{DateTime, Duration, Months}
 import org.json4s.JsonDSL._
+import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.json4s.jackson.Serialization.write
+
+import scala.util.{Success, Try}
 
 package object pings {
   case class Event(
@@ -234,11 +232,13 @@ package object pings {
     }
   }
 
+  case class CrashMetadata(StartupCrash: Option[String])
+
   case class CrashPayload(
       crashDate: String,
       processType: Option[String],
       hasCrashEnvironment: Option[Boolean],
-      metadata: Option[Map[String, String]],
+      metadata: CrashMetadata,
       version: Option[Int])
 
   case class CrashPing(
@@ -250,6 +250,10 @@ package object pings {
 
     def isMainCrash: Boolean = {
       payload.processType.getOrElse("main") == "main"
+    }
+
+    def isStartupCrash: Boolean = {
+      payload.metadata.StartupCrash.getOrElse("0") == "1"
     }
   }
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -10,13 +10,13 @@ import com.mozilla.spark.sql.hyperloglog.functions._
 import com.mozilla.telemetry.heka.{Dataset, Message}
 import com.mozilla.telemetry.pings._
 import com.mozilla.telemetry.timeseries._
-import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
-import org.apache.spark.sql.functions.{sum, window, col, expr}
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.functions.{col, expr, sum, window}
+import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.joda.time.{DateTime, Days, format}
 import org.json4s._
 import org.rogach.scallop.{ScallopConf, ScallopOption}
-import org.joda.time.{DateTime, Days, format}
 
 object ErrorAggregator {
   private val dateFormat = "yyyyMMdd"
@@ -125,6 +125,7 @@ object ErrorAggregator {
     .add[Int]("count")
     .add[Int]("subsession_count")
     .add[Int]("main_crashes")
+    .add[Int]("startup_crashes")
     .add[Int]("content_crashes")
     .add[Int]("gpu_crashes")
     .add[Int]("plugin_crashes")
@@ -247,6 +248,7 @@ object ErrorAggregator {
     stats("count") = Some(1)
     stats("client_id") = ping.meta.clientId
     stats("main_crashes") = Some(1)
+    stats("startup_crashes") = if (ping.isStartupCrash) Some(1) else None
 
     dimensions.map(RowBuilder.merge(_, stats.build))
   }


### PR DESCRIPTION
This adds `startup_crashes` metric, based on Error Ping's `payload.metadata.StartupCrash`.