### PR TITLE
Bug 1434378 - Track startup crashes in experiment_error_aggregates

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
@@ -29,6 +29,7 @@ object ExperimentsErrorAggregator {
     .add[Int]("count")
     .add[Int]("subsession_count")
     .add[Int]("main_crashes")
+    .add[Int]("startup_crashes")
     .add[Int]("content_crashes")
     .add[Int]("gpu_crashes")
     .add[Int]("plugin_crashes")


### PR DESCRIPTION
Previous PR (https://github.com/mozilla/telemetry-streaming/pull/113) missed experiment_error_aggregates.