### PR TITLE
Bug 1393144 - Use submission_date_s3 for partitioning error_aggregates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import sys.process._;
+
+import scala.sys.process._;
 
 val localMavenHttps = "https://s3-us-west-2.amazonaws.com/net-mozaws-data-us-west-2-ops-mavenrepo/"
 
@@ -19,7 +20,7 @@ organization := "com.mozilla"
 
 scalaVersion in ThisBuild := "2.11.8"
 
-val sparkVersion = "2.2.0"
+val sparkVersion = "2.3.0"
 
 lazy val root = (project in file(".")).
   settings(
@@ -29,7 +30,8 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
     libraryDependencies += "org.apache.spark" %% "spark-streaming" % sparkVersion % "provided",
     libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-    libraryDependencies += "org.apache.spark" %% "spark-sql-kafka-0-10" % sparkVersion,
+    libraryDependencies += "org.apache.spark" %% "spark-sql-kafka-0-10" % sparkVersion
+      exclude("net.jpountz.lz4", "lz4"), //conflicts with org.lz4:lz4-java:1.4.0 from spark-core
     libraryDependencies += "org.rogach" %% "scallop" % "1.0.2",
     libraryDependencies += "com.google.protobuf" % "protobuf-java" % "2.5.0",
     libraryDependencies += "joda-time" % "joda-time" % "2.9.2",

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -19,6 +19,7 @@ log4j.logger.parquet=ERROR
 
 # This reports useful info like num of rows processed per job
 log4j.logger.org.apache.spark.sql.execution.streaming.StreamExecution=INFO
+log4j.logger.org.apache.spark.sql.execution.streaming.MicroBatchExecution=INFO
 
 # SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
 log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL

--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
@@ -15,7 +15,7 @@ object ExperimentsErrorAggregator {
 
   val defaultDimensionsSchema = new SchemaBuilder()
     .add[Timestamp]("timestamp")  // Windowed
-    .add[Date]("submission_date")
+    .add[String]("submission_date_s3")
     .add[String]("channel")
     .add[String]("version")
     .add[String]("os_name")

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -79,7 +79,7 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
     // 1 for each experiment (there are 2), and one for a null experiment
     df.count() should be (3)
     val inspectedFields = List(
-      "submission_date",
+      "submission_date_s3",
       "channel",
       "version",
       "display_version",
@@ -120,7 +120,7 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
     val results = columns.zip(columns.map(field => query.collect().map(row => row.getAs[Any](field)).toSet) ).toMap
 
 
-    results("submission_date").map(_.toString) should be (Set("2016-04-07"))
+    results("submission_date_s3").map(_.toString) should be (Set("20160407"))
     results("channel") should be (Set(app.channel))
     results("version") should be (Set(app.version))
     results("display_version") should be (Set(app.displayVersion.getOrElse(null)))

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
@@ -49,7 +49,7 @@ class TestExperimentsErrorAggregator extends FlatSpec with Matchers {
     // 1 for each experiment (there are 2), and one for a null experiment
     df.count() should be (3)
     val inspectedFields = List(
-      "submission_date",
+      "submission_date_s3",
       "channel",
       "version",
       "os_name",
@@ -75,7 +75,7 @@ class TestExperimentsErrorAggregator extends FlatSpec with Matchers {
     val columns = query.columns
     val results = columns.zip(columns.map(field => query.collect().map(row => row.getAs[Any](field)).toSet) ).toMap
 
-    results("submission_date").map(_.toString) should be (Set("2016-04-07"))
+    results("submission_date_s3") should be (Set("20160407"))
     results("channel") should be (Set(app.channel))
     results("os_name") should be (Set("Linux"))
     results("country") should be (Set("IT"))


### PR DESCRIPTION
Also in separate commit: bump Spark version to 2.3.0 in order to use dynamic partition overwrite.