### PR TITLE
Use proper submission date format in normalized build_id extraction

### DIFF
--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -35,7 +35,7 @@ object TestUtils {
       "appBuildId" -> application.buildId,
       "geoCountry" -> "IT",
       "os" -> "Linux",
-      "submissionDate" -> "2017-01-01",
+      "submissionDate" -> "20170101",
       "environment.build" ->
         s"""
            |{
@@ -105,7 +105,7 @@ object TestUtils {
       "appBuildId" -> application.buildId,
       "geoCountry" -> "IT",
       "os" -> "Linux",
-      "submissionDate" -> "2017-01-01",
+      "submissionDate" -> "20170101",
       "environment.system" ->
         """
           |{
@@ -214,7 +214,7 @@ object TestUtils {
       "geoCountry" -> "CA",
       "geoCity" -> "Victoria",
       "sampleId" -> 73L,
-      "submissionDate" -> "2017-01-01",
+      "submissionDate" -> "20170101",
       "submission" -> """
       |{
       |  "v":1,

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -386,7 +386,7 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
     val messages = TestUtils.generateMainMessages(
       1, Some(Map(
         "environment.build" -> """{"buildId": "20170102"""",
-        "submissionDate" -> "2017-06-01"
+        "submissionDate" -> "20170601"
         )
       )
     ).map(_.toByteArray).seq
@@ -401,7 +401,7 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
     val messages2 = TestUtils.generateMainMessages(
       1, Some(Map(
         "environment.build" -> """{"buildId": "20170101"""",
-        "submissionDate" -> "2017-06-01"
+        "submissionDate" -> "20170601"
         )
       )
     ).map(_.toByteArray).seq


### PR DESCRIPTION
This fixes `normalizedBuildId`, which used incorrect date format.