### PR TITLE
Ping structure refactor

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/CorePing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/CorePing.scala
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.pings
+
+import com.mozilla.telemetry.heka.Message
+import org.json4s.DefaultFormats
+
+case class CorePing(arch: String,
+                    durations: Option[Int],
+                    experiments: Option[Array[String]],
+                    meta: Meta,
+                    os: String,
+                    osversion: String) extends Ping {
+
+  override def getExperiments: Array[(Option[String], Option[String])] = {
+    // add a null experiment_id and experiment_branch for each ping
+    // add a null experiment_branch for each experiment, as experiments on Fennec do not report branches
+    (experiments.map(_.map(e => (Option(e), Option.empty[String])))
+      .getOrElse(Array[(Option[String], Option[String])]()) :+ (None, None)
+      ).distinct
+  }
+
+  override def getVersion: Option[String] = Option(meta.appVersion)
+
+  override def getDisplayVersion: Option[String] = Option(meta.appVersion)
+
+  override def getOsName: Option[String] = Option(os)
+
+  override def getOsVersion: Option[String] = Option(osversion)
+
+  override def getArchitecture: Option[String] = Option(arch)
+
+  def usageHours: Option[Float] = {
+    val seconds_per_hour = 3600
+    this.durations match {
+      case Some(d) => Option(d.toFloat / seconds_per_hour)
+      case _ => None
+    }
+  }
+}
+
+object CorePing {
+  def apply(message: Message): CorePing = {
+    implicit val formats = DefaultFormats
+    val ping = messageToPing(message)
+    ping.extract[CorePing]
+  }
+}

--- a/src/main/scala/com/mozilla/telemetry/pings/CrashPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/CrashPing.scala
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.pings
+
+import com.mozilla.telemetry.heka.Message
+import org.json4s.DefaultFormats
+
+case class CrashPing(application: Application,
+                     clientId: Option[String],
+                     payload: CrashPayload,
+                     // Environment is omitted it's partially available under meta
+                     meta: Meta
+                    ) extends Ping with HasEnvironment with HasApplication {
+
+  def isMainCrash: Boolean = {
+    payload.processType.getOrElse("main") == "main"
+  }
+
+  def isContentCrash: Boolean = {
+    payload.processType.contains("content")
+  }
+
+  def isContentShutdownCrash: Boolean = {
+    payload.metadata.ipc_channel_error.contains("ShutDownKill")
+  }
+
+  def isStartupCrash: Boolean = {
+    payload.metadata.StartupCrash.getOrElse("0") == "1"
+  }
+}
+
+object CrashPing {
+  def apply(message: Message): CrashPing = {
+    implicit val formats = DefaultFormats
+    val jsonFieldNames = List(
+      "environment.build",
+      "environment.settings",
+      "environment.system",
+      "environment.profile",
+      "environment.addons",
+      "environment.experiments"
+    )
+    val ping = messageToPing(message, jsonFieldNames)
+    ping.extract[CrashPing]
+  }
+}
+
+case class CrashMetadata(StartupCrash: Option[String],
+                         ipc_channel_error: Option[String])
+
+case class CrashPayload(crashDate: String,
+                        processType: Option[String],
+                        hasCrashEnvironment: Option[Boolean],
+                        metadata: CrashMetadata,
+                        version: Option[Int])

--- a/src/main/scala/com/mozilla/telemetry/pings/FocusEvent.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/FocusEvent.scala
@@ -3,65 +3,86 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.pings
 
-import org.json4s._
-
 import java.security.MessageDigest
-import scala.util.hashing.MurmurHash3
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.github.fge.jsonschema.main.JsonSchemaFactory
 import com.mozilla.telemetry.heka.Message
 import com.mozilla.telemetry.streaming.EventsToAmplitude.Config
-
-import org.json4s._
 import org.json4s.JsonDSL._
+import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+case class Event(timestamp: Int,
+                 category: String,
+                 method: String,
+                 `object`: String,
+                 value: Option[String],
+                 extra: Option[Map[String, String]]) {
 
-import com.github.fge.jsonschema.main.{JsonSchema, JsonSchemaFactory}
-import com.github.fge.jsonschema.core.exceptions.ProcessingException
+  def getProperties(properties: Option[Map[String, String]]): JObject = {
+    properties.getOrElse(Map.empty).map { case (k, v) =>
+      k -> (v match {
+        case "timestamp" => timestamp.toString
+        case "category" => category
+        case "method" => method
+        case "object" => `object`
+        case "value" => value.getOrElse("") // TODO - log if empty
+        case e if e.startsWith("extra") => extra.getOrElse(Map.empty).getOrElse(e.stripPrefix("extra."), "")
+        case _ => ""
+      })
+    }.foldLeft(JObject())(_ ~ _)
+  }
 
-import scala.util.{Try, Success, Failure}
+  def getId: String = timestamp.toString + category + method + `object`
+}
 
+case class FocusSettings(pref_privacy_block_ads: Option[String],
+                         pref_locale: Option[String],
+                         pref_privacy_block_social: Option[String],
+                         pref_secure: Option[String],
+                         pref_privacy_block_analytics: Option[String],
+                         pref_search_engine: Option[String],
+                         pref_privacy_block_other: Option[String],
+                         pref_default_browser: Option[String],
+                         pref_performance_block_webfonts: Option[String],
+                         pref_performance_block_images: Option[String],
+                         pref_autocomplete_installed: Option[String],
+                         pref_autocomplete_custom: Option[String]) {
 
-case class FocusSettings(
-    pref_privacy_block_ads: Option[String],
-    pref_locale: Option[String],
-    pref_privacy_block_social: Option[String],
-    pref_secure: Option[String],
-    pref_privacy_block_analytics: Option[String],
-    pref_search_engine: Option[String],
-    pref_privacy_block_other: Option[String],
-    pref_default_browser: Option[String],
-    pref_performance_block_webfonts: Option[String],
-    pref_performance_block_images: Option[String],
-    pref_autocomplete_installed: Option[String],
-    pref_autocomplete_custom: Option[String]){
+  def blockAds: Option[Boolean] = asBool(pref_privacy_block_ads)
+
+  def blockSocial: Option[Boolean] = asBool(pref_privacy_block_social)
 
   def asBool(param: Option[String]): Option[Boolean] = param.map(_ == "true")
 
-  def blockAds: Option[Boolean] = asBool(pref_privacy_block_ads)
-  def blockSocial: Option[Boolean] = asBool(pref_privacy_block_social)
   def secure: Option[Boolean] = asBool(pref_secure)
+
   def blockAnalytics: Option[Boolean] = asBool(pref_privacy_block_analytics)
+
   def blockOther: Option[Boolean] = asBool(pref_privacy_block_other)
+
   def defaultBrowser: Option[Boolean] = asBool(pref_default_browser)
+
   def blockWebfonts: Option[Boolean] = asBool(pref_performance_block_webfonts)
+
   def blockImages: Option[Boolean] = asBool(pref_performance_block_images)
+
   def autocompleteInstalled: Option[Boolean] = asBool(pref_autocomplete_installed)
+
   def autocompleteCustom: Option[Boolean] = asBool(pref_autocomplete_custom)
 }
 
 
-case class FocusEventPing(
-    clientId: String,
-    created: Long,
-    events: Seq[Event],
-    v: String,
-    seq: Integer,
-    os: String,
-    osversion: String,
-    settings: FocusSettings,
-    meta: Meta) {
+case class FocusEventPing(clientId: String,
+                          created: Long,
+                          events: Seq[Event],
+                          v: String,
+                          seq: Integer,
+                          os: String,
+                          osversion: String,
+                          settings: FocusSettings,
+                          meta: Meta) {
 
   def getEvents(config: Config): String = {
     implicit val formats = DefaultFormats
@@ -72,16 +93,16 @@ case class FocusEventPing(
     val clientid = getHashedClientId
     val sessionId = getSessionId
 
-    val eventsList = events.map{ e => e -> asJsonNode(Extraction.decompose(e)): (Event, JsonNode) }
-        .map{ case(e, es) => // for each event, try each schema
-          e -> schemas.map( ts => ts.validateUnchecked(es).isSuccess )
-            .zip(config.events)
-            .filter(_._1)
+    val eventsList = events.map { e => e -> asJsonNode(Extraction.decompose(e)): (Event, JsonNode) }
+      .map { case (e, es) => // for each event, try each schema
+        e -> schemas.map(ts => ts.validateUnchecked(es).isSuccess)
+          .zip(config.events)
+          .filter(_._1)
       }
-      .filter{ case(e, es) => !es.isEmpty } // only keep those with a match
-      .map{ case(e, es) => e -> es.head._2 } // take the first match (head._1 is the bool)
-      .map{ case(e, es) =>
-        ("device_id" -> clientId) ~
+      .filter { case (e, es) => !es.isEmpty } // only keep those with a match
+      .map { case (e, es) => e -> es.head._2 } // take the first match (head._1 is the bool)
+      .map { case (e, es) =>
+      ("device_id" -> clientId) ~
         ("session_id" -> sessionId) ~
         ("insert_id" -> (clientId + sessionId.toString + e.getId)) ~
         ("event_type" -> getFullEventName(config.eventGroupName, es.name)) ~
@@ -94,18 +115,18 @@ case class FocusEventPing(
         ("city" -> meta.geoCity) ~
         ("user_properties" ->
           ("pref_privacy_block_ads" -> settings.blockAds) ~
-          ("pref_locale" -> settings.pref_locale) ~
-          ("pref_privacy_block_social" -> settings.blockSocial) ~
-          ("pref_secure" -> settings.secure) ~
-          ("pref_privacy_block_analytics" -> settings.blockAnalytics) ~
-          ("pref_search_engine" -> settings.pref_search_engine) ~
-          ("pref_privacy_block_other" -> settings.blockOther) ~
-          ("pref_default_browser" -> settings.defaultBrowser) ~
-          ("pref_performance_block_webfonts" -> settings.blockWebfonts) ~
-          ("pref_performance_block_images" -> settings.blockImages) ~
-          ("pref_autocomplete_installed" -> settings.autocompleteInstalled) ~
-          ("pref_autocomplete_custom" -> settings.autocompleteCustom))
-      }
+            ("pref_locale" -> settings.pref_locale) ~
+            ("pref_privacy_block_social" -> settings.blockSocial) ~
+            ("pref_secure" -> settings.secure) ~
+            ("pref_privacy_block_analytics" -> settings.blockAnalytics) ~
+            ("pref_search_engine" -> settings.pref_search_engine) ~
+            ("pref_privacy_block_other" -> settings.blockOther) ~
+            ("pref_default_browser" -> settings.defaultBrowser) ~
+            ("pref_performance_block_webfonts" -> settings.blockWebfonts) ~
+            ("pref_performance_block_images" -> settings.blockImages) ~
+            ("pref_autocomplete_installed" -> settings.autocompleteInstalled) ~
+            ("pref_autocomplete_custom" -> settings.autocompleteCustom))
+    }
 
     compact(render(eventsList))
   }
@@ -122,18 +143,18 @@ case class FocusEventPing(
   def includePing(sample: Double, config: Config): Boolean = {
     val keepClient = meta.sampleId.getOrElse(sample * 100) < (sample * 100)
 
-    if(!keepClient){
+    if (!keepClient) {
       // for maybe a slight perf increase
       return false // scalastyle:ignore
     }
 
     val currentProps = this.getClass
-      .getDeclaredFields.map{ e =>
-        e.setAccessible(true)
-        e.getName -> e.get(this).toString
-      }.toMap
+      .getDeclaredFields.map { e =>
+      e.setAccessible(true)
+      e.getName -> e.get(this).toString
+    }.toMap
 
-    config.filters.map{ case(prop, allowedVals) =>
+    config.filters.map { case (prop, allowedVals) =>
       allowedVals.contains(currentProps.getOrElse(prop, allowedVals.head))
     }.foldLeft(true)(_ & _)
   }

--- a/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.pings
+
+import com.mozilla.telemetry.heka.Message
+import org.json4s.{DefaultFormats, JNothing, JValue, _}
+
+import scala.util.{Success, Try}
+
+
+case class MainPing(application: Application,
+                    clientId: Option[String],
+                    // Environment omitted because it's mostly available under meta
+                    meta: Meta,
+                    payload: MainPingPayload
+                   ) extends Ping with HasEnvironment with HasApplication {
+  def getCountHistogramValue(histogram_name: String): Option[Int] = {
+    try {
+      this.meta.`payload.histograms` \ histogram_name \ "values" \ "0" match {
+        case JInt(count) => Some(count.toInt)
+        case _ => None
+      }
+    } catch {
+      case _: Throwable => None
+    }
+  }
+
+  def getCountKeyedHistogramValue(histogram_name: String, key: String): Option[Int] = {
+    try {
+      this.meta.`payload.keyedHistograms` \ histogram_name \ key \ "values" \ "0" match {
+        case JInt(count) => Some(count.toInt)
+        case _ => None
+      }
+    } catch {
+      case _: Throwable => None
+    }
+  }
+
+  // Return the number of values greater than threshold
+  def histogramThresholdCount(histogramName: String, threshold: Int, processType: String): Long = {
+    implicit val formats = org.json4s.DefaultFormats
+    val histogram = processType match {
+      case "main" => this.meta.`payload.histograms`
+      case _ => this.payload.processes \ processType \ "histograms"
+    }
+
+    histogram \ histogramName \ "values" match {
+      case JNothing => 0
+      case v => Try(v.extract[Map[String, Int]]) match {
+        case Success(m) =>
+          m.filterKeys(s => Try(s.toInt).toOption match {
+            case Some(key) => key >= threshold
+            case None => false
+          }).foldLeft(0)(_ + _._2)
+        case _ => 0
+      }
+    }
+  }
+
+  def usageHours: Option[Float] = {
+    val seconds_per_hour = 3600
+    val max_hours = 25
+    val min_hours = 0
+    try {
+      this.meta.`payload.info` \ "subsessionLength" match {
+        case JInt(length) => Some(Math.min(max_hours, Math.max(min_hours, length.toFloat / seconds_per_hour)))
+        case _ => None
+      }
+    } catch {
+      case _: Throwable => None
+    }
+  }
+
+  /*
+  * firstPaint is tricky because we only want to know this value if it
+  * comes from the first subsession.
+  */
+  def firstPaint: Option[Int] = {
+    this.isFirstSubsession match {
+      case Some(true) => this.meta.`payload.simpleMeasurements` \ "firstPaint" match {
+        case JInt(value) => Some(value.toInt)
+        case _ => None
+      }
+      case _ => None
+    }
+  }
+
+  def isFirstSubsession: Option[Boolean] = {
+    this.meta.`payload.info` \ "subsessionCounter" match {
+      case JInt(v) => Some(v == 1)
+      case _ => None
+    }
+  }
+
+  def sessionId: Option[String] = {
+    this.meta.`payload.info` \ "sessionId" match {
+      case JString(v) => Some(v)
+      case _ => None
+    }
+  }
+
+}
+
+object MainPing {
+
+  val processTypes = ("main", "content")
+
+  def apply(message: Message): MainPing = {
+    implicit val formats = DefaultFormats
+    val jsonFieldNames = List(
+      "environment.build",
+      "environment.settings",
+      "environment.system",
+      "environment.profile",
+      "environment.addons",
+      "environment.experiments",
+      "payload.simpleMeasurements",
+      "payload.keyedHistograms",
+      "payload.histograms",
+      "payload.info"
+    )
+    val ping = messageToPing(message, jsonFieldNames)
+    ping.extract[MainPing]
+  }
+}
+
+case class MainPingPayload(processes: JValue)

--- a/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.pings
+
+import java.sql.Timestamp
+
+import com.mozilla.telemetry.pings.Meta._
+import org.joda.time.Months
+import org.joda.time.format.DateTimeFormat
+import org.json4s.JValue
+
+trait Ping {
+  val meta: Meta
+
+  def getExperiments: Array[(Option[String], Option[String])]
+
+  def getVersion: Option[String]
+
+  def getDisplayVersion: Option[String]
+
+  def getOsName: Option[String]
+
+  def getOsVersion: Option[String]
+
+  def getArchitecture: Option[String]
+}
+
+trait HasEnvironment {
+  this: Ping =>
+
+  override def getExperiments: Array[(Option[String], Option[String])] = {
+    val oldStyleExperiment = for {
+      addons <- meta.`environment.addons`
+      experiment <- addons.activeExperiment
+    } yield (Some(experiment.id), Some(experiment.branch))
+
+    val newStyleExperiments = for {
+      experiments <- meta.`environment.experiments`.toSeq
+      (experimentId, experiment) <- experiments
+    } yield (Some(experimentId), Some(experiment.branch))
+
+    // add a null experiment_id and experiment_branch for each ping
+    (newStyleExperiments ++ oldStyleExperiment :+ (None, None)).toSet.toArray
+  }
+
+  override def getVersion: Option[String] = meta.`environment.build`.flatMap(_.version)
+
+  override def getOsName: Option[String] = meta.`environment.system`.map(_.os.name)
+
+  override def getOsVersion: Option[String] = meta.`environment.system`.map(_.os.normalizedVersion)
+
+  override def getArchitecture: Option[String] = meta.`environment.build`.flatMap(_.architecture)
+}
+
+case class EnvironmentBuild(version: Option[String],
+                            buildId: Option[String],
+                            architecture: Option[String])
+
+trait HasApplication {
+  this: Ping =>
+
+  val application: Application
+
+  override def getDisplayVersion: Option[String] = application.displayVersion
+}
+
+case class Application(architecture: String,
+                       buildId: String,
+                       channel: String,
+                       name: String,
+                       platformVersion: String,
+                       vendor: String,
+                       version: String,
+                       displayVersion: Option[String],
+                       xpcomAbi: String)
+
+case class OS(name: Option[String], version: Option[String]) {
+  val versionRegex = "(\\d+(\\.\\d+)?(\\.\\d+)?)?.*".r
+  val normalizedVersion: String = {
+    version match {
+      case Some(v) =>
+        val versionRegex(normalized, b, c) = v
+        normalized
+      case None =>
+        null
+    }
+  }
+}
+
+case class SystemOs(name: String, version: String) {
+  val normalizedVersion: String = OS(Option(name), Option(version)).normalizedVersion
+}
+
+case class System(os: SystemOs)
+
+case class OldStyleExperiment(id: String, branch: String)
+
+case class NewStyleExperiment(branch: String)
+
+case class ActiveAddon(isSystem: Option[Boolean], isWebExtension: Option[Boolean])
+
+object Theme {
+  val newThemes = List(
+    "{972ce4c6-7e08-4474-a285-3208198ce6fd}",
+    "firefox-compact-light@mozilla.org",
+    "firefox-compact-dark@mozilla.org"
+  )
+}
+
+case class Theme(id: String) {
+  def isOld: Boolean = !Theme.newThemes.contains(this.id)
+}
+
+case class Addons(activeAddons: Option[Map[String, ActiveAddon]],
+                  activeExperiment: Option[OldStyleExperiment],
+                  theme: Option[Theme])
+
+case class Settings(blocklistEnabled: Option[Boolean],
+                    isDefaultBrowser: Option[Boolean],
+                    locale: Option[String],
+                    telemetryEnabled: Option[Boolean])
+
+case class Meta(Host: Option[String],
+                Hostname: Option[String],
+                Size: Option[Double],
+                Timestamp: Long,
+                Type: Option[String],
+                appBuildId: String,
+                appName: String,
+                appUpdateChannel: Option[String],
+                appVendor: Option[String],
+                appVersion: String,
+                clientId: Option[String],
+                creationTimestamp: Option[Float],
+                docType: Option[String],
+                documentId: Option[String],
+                geoCity: Option[String],
+                geoCountry: String,
+                normalizedChannel: String,
+                os: Option[String],
+                sampleId: Option[Double],
+                sourceName: Option[String],
+                sourceVersion: Option[Int],
+                submissionDate: String,
+                telemetryEnabled: Option[Boolean],
+                // Common fields preparsed by hindsight
+                `environment.build`: Option[EnvironmentBuild],
+                `environment.settings`: Option[Settings],
+                `environment.system`: Option[System],
+                `environment.addons`: Option[Addons],
+                `environment.experiments`: Option[Map[String, NewStyleExperiment]],
+                // Main ping fields preparsed by hindsight
+                `payload.simpleMeasurements`: JValue,
+                `payload.keyedHistograms`: JValue,
+                `payload.histograms`: JValue,
+                `payload.info`: JValue) {
+  // Some of the fields are not present in all ping types (e.g. `environment.*`, `payload.*`
+  // This class contains only extractor methods for common fields, sent with all pings
+  def normalizedBuildId: Option[String] = {
+    `environment.build`.flatMap(_.buildId) match {
+      case Some(buildId: String) =>
+        val buildIdDay = buildId.slice(0, 8)
+        val buildDateTime = BuildDateFormat.parseDateTime(buildIdDay)
+        val submissionDateTime = SubmissionDateFormat.parseDateTime(submissionDate)
+
+        Months.monthsBetween(buildDateTime, submissionDateTime).getMonths match {
+          case m if (0 <= m) && (m <= 6) => Some(buildId)
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  /**
+    * Returns a java Timestamp obj with microseconds resolution.
+    * The source Timestamp field has nanoseconds resolution
+    */
+  def normalizedTimestamp(): Timestamp = {
+    new Timestamp(this.Timestamp / 1000000)
+  }
+}
+
+object Meta {
+  private[pings] val BuildDateFormat = DateTimeFormat.forPattern("yyyyMMdd")
+  private[pings] val SubmissionDateFormat = DateTimeFormat.forPattern("yyyyMMdd")
+}

--- a/src/main/scala/com/mozilla/telemetry/pings/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/package.scala
@@ -364,6 +364,47 @@ package object pings {
     }
   }
 
+  case class CorePing(
+      arch: String,
+      durations: Option[Int],
+      experiments: Option[Array[String]],
+      meta: Meta,
+      os: String,
+      osversion: String) {
+    def usageHours: Option[Float] = {
+      val seconds_per_hour = 3600
+      this.durations match {
+        case Some(d) => Option(d.toFloat / seconds_per_hour)
+        case _ => None
+      }
+    }
+  }
+
+  object CorePing {
+    def apply(message: Message): CorePing = {
+      implicit val formats = DefaultFormats
+      val ping = messageToPing(message)
+      ping.extract[CorePing]
+    }
+  }
+
+  def messageToPing(message: Message, jsonFieldNames: List[String] = List(), eventPaths: List[List[String]] = List()): JValue = {
+    implicit val formats = DefaultFormats
+    val fields = message.fieldsAsMap ++ Map("Timestamp" -> message.timestamp)
+    val jsonObj = Extraction.decompose(fields)
+    // Transform json fields into JValues
+    val meta = jsonObj transformField {
+      case JField(key, JString(s)) if jsonFieldNames contains key => (key, parse(s))
+    }
+    val submission = if(message.payload.isDefined) message.payload else fields.get("submission")
+    val json = submission match {
+      case Some(value: String) => parse(value)
+      case _ => JObject()
+    }
+
+    replaceEvents(json, eventPaths) ++ JObject(List(JField("meta", meta)))
+  }
+
   /**
    * Events come in as arrays, but to extract them to Event case classes
    * we need them as key-value json blobs. This takes in a list of event
@@ -398,22 +439,5 @@ package object pings {
 
         currentJson.replace(path, newEvents)
     }
-  }
-
-  def messageToPing(message: Message, jsonFieldNames: List[String], eventPaths: List[List[String]] = List()): JValue = {
-    implicit val formats = DefaultFormats
-    val fields = message.fieldsAsMap ++ Map("Timestamp" -> message.timestamp)
-    val jsonObj = Extraction.decompose(fields)
-    // Transform json fields into JValues
-    val meta = jsonObj transformField {
-      case JField(key, JString(s)) if jsonFieldNames contains key => (key, parse(s))
-    }
-    val submission = if(message.payload.isDefined) message.payload else fields.get("submission")
-    val json = submission match {
-      case Some(value: String) => parse(value)
-      case _ => JObject()
-    }
-
-    replaceEvents(json, eventPaths) ++ JObject(List(JField("meta", meta)))
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/pings/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/package.scala
@@ -3,390 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry
 
-import java.sql.Timestamp
-
 import com.mozilla.telemetry.heka.Message
-import com.mozilla.telemetry.pings.Meta._
-import org.joda.time.Months
-import org.joda.time.format.DateTimeFormat
-import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
-import scala.util.{Success, Try}
-
 package object pings {
-  case class Event(
-      timestamp: Int,
-      category: String,
-      method: String,
-      `object`: String,
-      value: Option[String],
-      extra: Option[Map[String, String]]){
-
-    def getProperties(properties: Option[Map[String, String]]): JObject = {
-      properties.getOrElse(Map.empty).map{ case(k, v) =>
-        k -> (v match {
-          case "timestamp" => timestamp.toString
-          case "category" => category
-          case "method" => method
-          case "object" => `object`
-          case "value" => value.getOrElse("") // TODO - log if empty
-          case e if e.startsWith("extra") => extra.getOrElse(Map.empty).getOrElse(e.stripPrefix("extra."), "")
-          case _ => ""
-        })
-      }.foldLeft(JObject())(_ ~ _)
-    }
-
-    def getId: String = timestamp.toString + category + method + `object`
-  }
-
-  case class Application(
-      architecture: String,
-      buildId: String,
-      channel: String,
-      name: String,
-      platformVersion: String,
-      vendor: String,
-      version: String,
-      displayVersion: Option[String],
-      xpcomAbi: String)
-
-  case class Build(
-      applicationId: Option[String],
-      applicationName: Option[String],
-      architecture: String,
-      buildId: String,
-      platformVersion: String,
-      vendor: String,
-      version: String,
-      xpcomAbi: String)
-
-  case class SystemOs(name: String, version: String) {
-    val normalizedVersion: String = OS(Option(name), Option(version)).normalizedVersion
-  }
-
-  case class System(os: SystemOs)
-
-  case class OldStyleExperiment(id: String, branch: String)
-
-  case class NewStyleExperiment(branch: String)
-
-  case class ActiveAddon(isSystem: Option[Boolean], isWebExtension: Option[Boolean])
-
-  object Theme {
-    val newThemes = List(
-      "{972ce4c6-7e08-4474-a285-3208198ce6fd}",
-      "firefox-compact-light@mozilla.org",
-      "firefox-compact-dark@mozilla.org"
-    )
-  }
-
-  case class Theme(id: String) {
-    def isOld: Boolean = ! Theme.newThemes.contains(this.id)
-  }
-
-  case class Addons(
-      activeAddons: Option[Map[String, ActiveAddon]],
-      activeExperiment: Option[OldStyleExperiment],
-      theme: Option[Theme]
-  )
-
-  case class Settings(
-      blocklistEnabled: Option[Boolean],
-      isDefaultBrowser: Option[Boolean],
-      locale: Option[String],
-      telemetryEnabled: Option[Boolean])
-
-  case class Meta(
-      Host: Option[String],
-      Hostname: Option[String],
-      Size: Option[Double],
-      Timestamp: Long,
-      Type: Option[String],
-      appBuildId: String,
-      appName: String,
-      appUpdateChannel: Option[String],
-      appVendor: Option[String],
-      appVersion: String,
-      clientId: Option[String],
-      creationTimestamp: Option[Float],
-      docType: Option[String],
-      documentId: Option[String],
-      geoCity: Option[String],
-      geoCountry: String,
-      normalizedChannel: String,
-      os: Option[String],
-      sampleId: Option[Double],
-      sourceName: Option[String],
-      sourceVersion: Option[Int],
-      submissionDate: String,
-      telemetryEnabled: Option[Boolean],
-      // Common fields preparsed by hindsight
-      `environment.build`: Option[EnvironmentBuild],
-      `environment.settings`: Option[Settings],
-      `environment.system`: Option[System],
-      `environment.addons`: Option[Addons],
-      `environment.experiments`: Option[Map[String, NewStyleExperiment]],
-      // Main ping fields preparsed by hindsight
-      `payload.simpleMeasurements`: JValue,
-      `payload.keyedHistograms`: JValue,
-      `payload.histograms`: JValue,
-      `payload.info`: JValue) {
-
-    /**
-      * Returns a java Timestamp obj with microseconds resolution.
-      * The source Timestamp field has nanoseconds resolution
-      */
-    def normalizedTimestamp(): Timestamp = {
-      new Timestamp(this.Timestamp / 1000000)
-    }
-
-    val normalizedBuildId: Option[String] = {
-      `environment.build`.flatMap(_.buildId) match {
-        case Some(buildId: String) =>
-          val buildIdDay = buildId.slice(0, 8)
-          val buildDateTime = BuildDateFormat.parseDateTime(buildIdDay)
-          val submissionDateTime = SubmissionDateFormat.parseDateTime(submissionDate)
-
-          Months.monthsBetween(buildDateTime, submissionDateTime).getMonths match {
-            case m if (0 <= m) && (m <= 6) => Some(buildId)
-            case _ => None
-          }
-        case _ => None
-      }
-    }
-
-    def experiments: Seq[(Option[String], Option[String])] = {
-      val oldStyleExperiment = for {
-        addons <- this.`environment.addons`
-        experiment <- addons.activeExperiment
-      } yield (Some(experiment.id), Some(experiment.branch))
-
-      val newStyleExperiments = for {
-        experiments <- this.`environment.experiments`.toSeq
-        (experimentId, experiment) <- experiments
-      } yield (Some(experimentId), Some(experiment.branch))
-
-      newStyleExperiments ++ oldStyleExperiment
-    }
-  }
-
-  object Meta {
-    private[pings] val BuildDateFormat = DateTimeFormat.forPattern("yyyyMMdd")
-    private[pings] val SubmissionDateFormat = DateTimeFormat.forPattern("yyyyMMdd")
-  }
-
-  case class CrashMetadata(
-      StartupCrash: Option[String],
-      ipc_channel_error: Option[String])
-
-  case class CrashPayload(
-      crashDate: String,
-      processType: Option[String],
-      hasCrashEnvironment: Option[Boolean],
-      metadata: CrashMetadata,
-      version: Option[Int])
-
-  case class CrashPing(
-      application: Application,
-      clientId: Option[String],
-      payload: CrashPayload,
-      // Environment is omitted it's partially available under meta
-      meta: Meta) {
-
-    def isMainCrash: Boolean = {
-      payload.processType.getOrElse("main") == "main"
-    }
-
-    def isContentCrash: Boolean = {
-      payload.processType.contains("content")
-    }
-
-    def isContentShutdownCrash: Boolean = {
-      payload.metadata.ipc_channel_error.contains("ShutDownKill")
-    }
-
-    def isStartupCrash: Boolean = {
-      payload.metadata.StartupCrash.getOrElse("0") == "1"
-    }
-  }
-
-  object CrashPing {
-    def apply(message: Message): CrashPing = {
-      implicit val formats = DefaultFormats
-      val jsonFieldNames = List(
-        "environment.build",
-        "environment.settings",
-        "environment.system",
-        "environment.profile",
-        "environment.addons",
-        "environment.experiments"
-      )
-      val ping = messageToPing(message, jsonFieldNames)
-      ping.extract[CrashPing]
-    }
-  }
-
-  case class PayloadInfo(subsessionLength: Option[Int])
-
-  case class MainPingPayload(processes: JValue)
-
-  case class MainPing(
-      application: Application,
-      clientId: Option[String],
-      // Environment omitted because it's mostly available under meta
-      meta: Meta,
-      payload: MainPingPayload
-  ) {
-    def getCountHistogramValue(histogram_name: String): Option[Int] = {
-      try {
-        this.meta.`payload.histograms` \ histogram_name \ "values" \ "0" match {
-          case JInt(count) => Some(count.toInt)
-          case _ => None
-        }
-      } catch { case _: Throwable => None }
-    }
-
-    def getCountKeyedHistogramValue(histogram_name: String, key: String): Option[Int] = {
-      try {
-        this.meta.`payload.keyedHistograms` \ histogram_name \ key \ "values" \ "0" match {
-          case JInt(count) => Some(count.toInt)
-          case _ => None
-        }
-      } catch { case _: Throwable => None }
-    }
-
-    // Return the number of values greater than threshold
-    def histogramThresholdCount(histogramName: String, threshold: Int, processType: String): Long = {
-      implicit val formats = org.json4s.DefaultFormats
-      val histogram = processType match {
-        case "main" => this.meta.`payload.histograms`
-        case _ => this.payload.processes \ processType \ "histograms"
-      }
-
-      histogram \ histogramName \ "values" match {
-        case JNothing => 0
-        case v => Try(v.extract[Map[String, Int]]) match {
-          case Success(m) =>
-            m.filterKeys(s => Try(s.toInt).toOption match {
-              case Some(key) => key >= threshold
-              case None => false
-            }).foldLeft(0)(_ + _._2)
-          case _ => 0
-        }
-      }
-    }
-
-    def usageHours: Option[Float] = {
-      val seconds_per_hour = 3600
-      val max_hours = 25
-      val min_hours = 0
-      try {
-        this.meta.`payload.info` \ "subsessionLength" match {
-          case JInt(length) => Some(Math.min(max_hours, Math.max(min_hours, length.toFloat / seconds_per_hour)))
-          case _ => None
-        }
-      } catch { case _: Throwable => None }
-    }
-
-    /*
-    * firstPaint is tricky because we only want to know this value if it
-    * comes from the first subsession.
-    */
-    def firstPaint: Option[Int] = {
-      this.isFirstSubsession match {
-        case Some(true) => this.meta.`payload.simpleMeasurements` \ "firstPaint" match {
-          case JInt(value) => Some(value.toInt)
-          case _ => None
-        }
-        case _ => None
-      }
-    }
-
-    def isFirstSubsession: Option[Boolean] = {
-      this.meta.`payload.info` \ "subsessionCounter" match {
-        case JInt(v)  => Some(v == 1)
-        case _ => None
-      }
-    }
-
-    def sessionId: Option[String] = {
-      this.meta.`payload.info` \ "sessionId" match {
-        case JString(v) => Some(v)
-        case _ => None
-      }
-    }
-
-  }
-  object MainPing {
-
-    val processTypes = ("main", "content")
-
-    def apply(message: Message): MainPing = {
-      implicit val formats = DefaultFormats
-      val jsonFieldNames = List(
-        "environment.build",
-        "environment.settings",
-        "environment.system",
-        "environment.profile",
-        "environment.addons",
-        "environment.experiments",
-        "payload.simpleMeasurements",
-        "payload.keyedHistograms",
-        "payload.histograms",
-        "payload.info"
-      )
-      val ping = messageToPing(message, jsonFieldNames)
-      ping.extract[MainPing]
-    }
-  }
-
-  case class Environment(build: EnvironmentBuild, system: EnvironmentSystem)
-
-  case class EnvironmentBuild(
-      version: Option[String],
-      buildId: Option[String],
-      architecture: Option[String])
-
-  case class EnvironmentSystem(os: OS)
-
-  case class OS(name: Option[String], version: Option[String]){
-    val versionRegex = "(\\d+(\\.\\d+)?(\\.\\d+)?)?.*".r
-    val normalizedVersion: String = {
-      version match {
-        case Some(v) =>
-          val versionRegex(normalized, b, c) = v
-          normalized
-        case None =>
-          null
-      }
-    }
-  }
-
-  case class CorePing(
-      arch: String,
-      durations: Option[Int],
-      experiments: Option[Array[String]],
-      meta: Meta,
-      os: String,
-      osversion: String) {
-    def usageHours: Option[Float] = {
-      val seconds_per_hour = 3600
-      this.durations match {
-        case Some(d) => Option(d.toFloat / seconds_per_hour)
-        case _ => None
-      }
-    }
-  }
-
-  object CorePing {
-    def apply(message: Message): CorePing = {
-      implicit val formats = DefaultFormats
-      val ping = messageToPing(message)
-      ping.extract[CorePing]
-    }
-  }
 
   def messageToPing(message: Message, jsonFieldNames: List[String] = List(), eventPaths: List[List[String]] = List()): JValue = {
     implicit val formats = DefaultFormats
@@ -396,7 +17,7 @@ package object pings {
     val meta = jsonObj transformField {
       case JField(key, JString(s)) if jsonFieldNames contains key => (key, parse(s))
     }
-    val submission = if(message.payload.isDefined) message.payload else fields.get("submission")
+    val submission = if (message.payload.isDefined) message.payload else fields.get("submission")
     val json = submission match {
       case Some(value: String) => parse(value)
       case _ => JObject()
@@ -406,27 +27,27 @@ package object pings {
   }
 
   /**
-   * Events come in as arrays, but to extract them to Event case classes
-   * we need them as key-value json blobs. This takes in a list of event
-   * paths (since some pings may hold events in multiple places), and
-   * converts each array to a json event that can be extracted.
-   */
+    * Events come in as arrays, but to extract them to Event case classes
+    * we need them as key-value json blobs. This takes in a list of event
+    * paths (since some pings may hold events in multiple places), and
+    * converts each array to a json event that can be extracted.
+    */
   def replaceEvents(json: JValue, eventPaths: List[List[String]]): JValue = {
-    eventPaths.foldLeft(json){
+    eventPaths.foldLeft(json) {
       case (currentJson, path) =>
         val currentEvents = path.foldLeft(currentJson)(_ \ _)
         val newEvents = currentEvents match {
-          case JArray(x) => JArray(x.map{ e =>
+          case JArray(x) => JArray(x.map { e =>
             e match {
               case JArray(event) =>
                 JObject(
-                  JField("timestamp", event(0))         ::
-                  JField("category", event(1))          ::
-                  JField("method", event(2))            ::
-                  JField("object", event(3))            ::
-                  JField("value", event.lift(4).getOrElse(JNull)) ::
-                  JField("extra", event.lift(5).getOrElse(JNull)) ::
-                  Nil)
+                  JField("timestamp", event(0)) ::
+                    JField("category", event(1)) ::
+                    JField("method", event(2)) ::
+                    JField("object", event(3)) ::
+                    JField("value", event.lift(4).getOrElse(JNull)) ::
+                    JField("extra", event.lift(5).getOrElse(JNull)) ::
+                    Nil)
 
               case o => throw new java.io.InvalidObjectException(
                 s"Expected JArray for event at ${path.mkString("\\")}, got ${o.getClass}")

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -12,19 +12,31 @@ import org.json4s.{DefaultFormats, Extraction, JField}
 
 object TestUtils {
   implicit val formats = DefaultFormats
-  val application = pings.Application(
+  val defaultFirefoxApplication = pings.Application(
     "x86", "20170101000000", "release", "Firefox", "42.0", "Mozilla", "42.0", Some("42.0b1"), "x86-msvc"
   )
+  val defaultFennecApplication = pings.Application(
+    "arm64-v8a", "20170101000000", "release", "Fennec", "59.0.2", "Mozilla", "59.0", Some("59.0.2"), "arm-eabi-gcc3"
+  )
+
   val scalarValue = 42
   val testTimestampNano = 1460036116829920000L
   val testTimestampMillis = testTimestampNano / 1000000
   val today = new DateTime(testTimestampMillis)
   val todayDays = new Duration(new DateTime(0), today).getStandardDays().toInt
 
-  def generateCrashMessages(size: Int, fieldsOverride: Option[Map[String, Any]] = None,
+  def generateCrashMessages(size: Int,
+                            fieldsOverride: Option[Map[String, Any]] = None,
                             customMetadata: Option[String] = None,
                             customPayload: Option[String] = None,
-                            timestamp: Option[Long] = None): Seq[Message] = {
+                            timestamp: Option[Long] = None,
+                            appType: AppType = Firefox): Seq[Message] = {
+
+    val application = appType match {
+      case Fennec => defaultFennecApplication
+      case _ => defaultFirefoxApplication
+    }
+
     val defaultMap = Map(
       "clientId" -> "client1",
       "docType" -> "crash",
@@ -98,11 +110,11 @@ object TestUtils {
     val defaultMap = Map(
       "clientId" -> "client1",
       "docType" -> "main",
-      "normalizedChannel" -> application.channel,
-      "appName" -> application.name,
-      "appVersion" -> application.version.toDouble,
-      "displayVersion" -> application.displayVersion.getOrElse(null),
-      "appBuildId" -> application.buildId,
+      "normalizedChannel" -> defaultFirefoxApplication.channel,
+      "appName" -> defaultFirefoxApplication.name,
+      "appVersion" -> defaultFirefoxApplication.version.toDouble,
+      "displayVersion" -> defaultFirefoxApplication.displayVersion.getOrElse(null),
+      "appBuildId" -> defaultFirefoxApplication.buildId,
       "geoCountry" -> "IT",
       "os" -> "Linux",
       "submissionDate" -> "20170101",
@@ -131,9 +143,9 @@ object TestUtils {
       "environment.build" ->
         s"""
           |{
-          |  "architecture": "${application.architecture}",
-          |  "buildId": "${application.buildId}",
-          |  "version": "${application.version}"
+          |  "architecture": "${defaultFirefoxApplication.architecture}",
+          |  "buildId": "${defaultFirefoxApplication.buildId}",
+          |  "version": "${defaultFirefoxApplication.version}"
           |}""".stripMargin,
       "payload.histograms" ->
         """{
@@ -168,7 +180,7 @@ object TestUtils {
       case Some(m) => defaultMap ++ m
       case _ => defaultMap
     }
-    val applicationData = Extraction.decompose(application) removeField {
+    val applicationData = Extraction.decompose(defaultFirefoxApplication) removeField {
       case JField(x, _) if fieldsToRemove.contains(x) => true
       case _ => false
     }
@@ -281,4 +293,73 @@ object TestUtils {
       )
     }
   }
+
+  // scalastyle:off methodLength
+  def generateFennecCoreMessages(size: Int, fieldsOverride: Option[Map[String, Any]] = None, timestamp: Option[Long] = None): Seq[Message] = {
+    val defaultMap = Map(
+      "appBuildId" -> defaultFennecApplication.buildId,
+      "appName" -> defaultFennecApplication.name,
+      "appUpdateChannel" -> defaultFennecApplication.channel,
+      "appVersion" -> defaultFennecApplication.version.toDouble,
+      "clientId" -> "ca7fb81d-5deb-4ea6-8b74-797b8e58cfae",
+      "Date" -> "Sun, 29 Apr 2018 15:35:38 GMT+00:00",
+      "docType" -> "core",
+      "documentId" -> "befd87f9-472d-4a38-9ae1-2f4668e10c62",
+      "geoCity" -> "Modena",
+      "geoCountry" -> "IT",
+      "geoSubdivision1" -> "45",
+      "geoSubdivision2" -> "MO",
+      "Host" -> "incoming.telemetry.mozilla.org",
+      "normalizedChannel" -> "release",
+      "sampleId" -> 22L,
+      "sourceName" -> "telemetry",
+      "sourceVersion" -> "9",
+      "submissionDate" -> "20180429",
+      "submission" ->
+        """
+          |{
+          |  "durations": 3600,
+          |  "device": "samsung-SM-G930F",
+          |  "experiments": [
+          |    "experiment1",
+          |    "experiment2"
+          |  ],
+          |  "tz": 120,
+          |  "flashUsage": 0,
+          |  "locale": "en-US",
+          |  "arch": "arm64-v8a",
+          |  "os": "Android",
+          |  "defaultSearch": "google",
+          |  "seq": 61,
+          |  "v": 9,
+          |  "clientId": "ca7fb81d-5deb-4ea6-8b74-797b8e58cfae",
+          |  "osversion": "42",
+          |  "sessions": 1,
+          |  "profileDate": 17622,
+          |  "defaultBrowser": false,
+          |  "created": "2018-04-29",
+          |  "searches": {
+          |    "google.actionbar": 1
+          |  }
+          |}
+        """.stripMargin
+    )
+    val outputMap = fieldsOverride match {
+      case Some(m) => defaultMap ++ m
+      case _ => defaultMap
+    }
+
+    1.to(size) map { index =>
+      RichMessage(s"core-ping-$index",
+        outputMap,
+        None,
+        timestamp = timestamp.getOrElse(testTimestampNano)
+      )
+    }
+  }
+  // scalastyle:on methodLength
+
+  abstract class AppType
+  case object Firefox extends AppType
+  case object Fennec extends AppType
 }

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
@@ -14,7 +14,7 @@ class TestExperimentsErrorAggregator extends FlatSpec with Matchers {
 
   implicit val formats = DefaultFormats
   val k = TestUtils.scalarValue
-  val app = TestUtils.application
+  val app = TestUtils.defaultFennecApplication
 
   val spark = SparkSession.builder()
     .appName("Error Aggregates")


### PR DESCRIPTION
As a follow up to https://github.com/mozilla/telemetry-streaming/pull/129, this is an attempt to make it more clear which fields are available in each ping.

Due to the way Hindsight parses messages, `meta` may be missing some fields for pings that are not fully in line with common format (e.g. `environment` and `application` objects).
In this commit:
* `Ping` trait is introduced
* concrete ping classes are moved to separate files
* information about presence of certain sections is encoded in ping types using `HasEnvironment` and `HasApplication` traits, which contain extractor methods with implementations specific to these sections
* generic `ErrorAggregator#buildDimensions` method handles all ping types
