### PR TITLE
Bug 1454047 - Remove unused metrics from error_aggregates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ val sparkVersion = "2.3.0"
 lazy val root = (project in file(".")).
   settings(
     libraryDependencies += "com.mozilla.telemetry" %% "moztelemetry" % "1.0-SNAPSHOT",
-    libraryDependencies += "com.mozilla.telemetry" %% "spark-hyperloglog" % "2.0.0-SNAPSHOT",
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % Test,
     libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
     libraryDependencies += "org.apache.spark" %% "spark-streaming" % sparkVersion % "provided",

--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
@@ -27,7 +27,6 @@ object ExperimentsErrorAggregator {
   val defaultMetricsSchema = new SchemaBuilder()
     .add[Float]("usage_hours")
     .add[Int]("count")
-    .add[Int]("subsession_count")
     .add[Int]("main_crashes")
     .add[Int]("startup_crashes")
     .add[Int]("content_crashes")
@@ -44,7 +43,6 @@ object ExperimentsErrorAggregator {
     ErrorAggregator.run(args,
       defaultDimensionsSchema,
       defaultMetricsSchema,
-      defaultCountHistogramErrorsSchema,
-      defaultThresholdHistograms)
+      defaultCountHistogramErrorsSchema)
   }
 }


### PR DESCRIPTION
Following fields are removed since they're not used and not needed in v2:
* `subsession_count`
* `first_subsession_count`
* `input_event_response_coalesced_ms_main_above_150`
* `input_event_response_coalesced_ms_main_above_250`
* `input_event_response_coalesced_ms_main_above_2500`
* `input_event_response_coalesced_ms_content_above_150`
* `input_event_response_coalesced_ms_content_above_250`
* `input_event_response_coalesced_ms_content_above_2500`
* `ghost_windows_main_above_1`
* `ghost_windows_content_above_1`
* `gc_max_pause_ms_2_main_above_150`
* `gc_max_pause_ms_2_main_above_250`
* `gc_max_pause_ms_2_main_above_2500`
* `gc_max_pause_ms_2_content_above_150`
* `gc_max_pause_ms_2_content_above_250`
* `gc_max_pause_ms_2_content_above_2500`
* `cycle_collector_max_pause_main_above_150`
* `cycle_collector_max_pause_main_above_250`
* `cycle_collector_max_pause_main_above_2500`
* `cycle_collector_max_pause_content_above_150`
* `cycle_collector_max_pause_content_above_250`
* `cycle_collector_max_pause_content_above_2500`