### PR TITLE
Bug 1464191 - Silence logs that are too verbose

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -12,14 +12,20 @@ log4j.logger.org.apache.spark.repl.Main=WARN
 # Settings to quiet third party logs that are too verbose
 log4j.logger.org.spark_project.jetty=WARN
 log4j.logger.org.spark_project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
 log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
 log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.spark.SparkContext=ERROR
+log4j.logger.org.apache.spark.sql.SparkSession$Builder=ERROR
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=ERROR
+log4j.logger.org.apache.spark.util.ClosureCleaner=ERROR
+log4j.logger.org.apache.spark.util.Utils=ERROR
 log4j.logger.org.apache.parquet=ERROR
 log4j.logger.parquet=ERROR
+log4j.logger.wiremock.org.eclipse.jetty.util.thread.QueuedThreadPool=ERROR
 
 # This reports useful info like num of rows processed per job
 log4j.logger.org.apache.spark.sql.execution.streaming.StreamExecution=INFO
-log4j.logger.org.apache.spark.sql.execution.streaming.MicroBatchExecution=INFO
 
 # SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
 log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL


### PR DESCRIPTION
I left this warning in place because it looks something that shouldn't be silenced in prod
<pre>
18/05/29 13:43:37 WARN SharedState: URL.setURLStreamHandlerFactory failed to set FsUrlStreamHandlerFactory
</pre>