### PR TITLE
Bug 1465442 - Add experiment enrollment event aggregator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,9 @@ lazy val root = (project in file(".")).
     libraryDependencies += "org.apache.kafka" %% "kafka" % "0.10.0.1" % Test,
     libraryDependencies += "org.scalaj" %% "scalaj-http" % "2.3.0",
     libraryDependencies += "com.github.tomakehurst" % "wiremock-standalone" % "2.14.0" % "provided",
-    libraryDependencies += "com.github.java-json-tools" % "json-schema-validator" % "2.2.8"
+    libraryDependencies += "com.github.java-json-tools" % "json-schema-validator" % "2.2.8",
+    libraryDependencies += "com.holdenkarau" %% "spark-testing-base" % "2.3.0_0.9.0" % Test,
+    libraryDependencies += "org.apache.spark" %% "spark-hive" % "2.3.0" % Test
   )
 
 // Setup docker task

--- a/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
@@ -99,6 +99,12 @@ case class MainPing(application: Application,
     }
   }
 
+  def getNormandyEvents: Seq[Event] = {
+    implicit val formats = org.json4s.DefaultFormats
+
+    val dynamicProcessEvents = (this.payload.processes \ "dynamic" \ "events").extract[Seq[Event]]
+    dynamicProcessEvents.filter(_.category == "normandy")
+  }
 }
 
 object MainPing {
@@ -119,7 +125,7 @@ object MainPing {
       "payload.histograms",
       "payload.info"
     )
-    val ping = messageToPing(message, jsonFieldNames)
+    val ping = messageToPing(message, jsonFieldNames, List("payload" :: "processes" :: "dynamic" :: "events" :: Nil))
     ping.extract[MainPing]
   }
 }

--- a/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
@@ -4,17 +4,13 @@
 package com.mozilla.telemetry.pings
 
 import java.sql.Timestamp
-import com.mozilla.telemetry.heka.Message
-import org.json4s._
-import org.json4s.jackson.JsonMethods._
 
 import com.mozilla.telemetry.heka.Message
 import com.mozilla.telemetry.pings.Meta._
 import org.joda.time.Months
 import org.joda.time.format.DateTimeFormat
-import org.json4s
 import org.json4s.jackson.JsonMethods.parse
-import org.json4s.{DefaultFormats, Extraction, JArray, JField, JNull, JObject, JValue}
+import org.json4s.{DefaultFormats, Extraction, JArray, JField, JNull, JObject, JValue, _}
 
 trait Ping {
   val meta: Meta
@@ -95,6 +91,8 @@ object Ping {
             case o => throw new java.io.InvalidObjectException(
               s"Expected JArray for event at ${path.mkString("\\")}, got ${o.getClass}")
           })
+
+          case JNothing => JNothing
 
           case o => throw new java.io.InvalidObjectException(
             s"Expected JArray for events container at ${path.mkString("\\")}, got ${o.getClass}")

--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentEnrollmentsAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentEnrollmentsAggregator.scala
@@ -1,0 +1,204 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.streaming
+
+import java.sql.Timestamp
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.time.{Instant, LocalDate, ZoneId}
+
+import com.mozilla.telemetry.heka.{Message, Dataset => MozDataset}
+import com.mozilla.telemetry.pings.MainPing
+import com.mozilla.telemetry.streaming.ErrorAggregator._
+import org.apache.spark
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+
+object ExperimentEnrollmentsAggregator {
+  val queryName = "experiment_enrollments"
+  val outputPrefix = "experiment_enrollments/v1"
+  val kafkaCacheMaxCapacity = 100
+  val dateFormat = "yyyyMMdd"
+  val dateFormatter = DateTimeFormatter.ofPattern(dateFormat)
+  private val allowedDocTypes = List("main")
+  private val allowedAppNames = List("Firefox")
+
+  def main(args: Array[String]): Unit = {
+    val opts = new Opts(args)
+
+    val spark = SparkSession.builder()
+      .appName("Experiment Enrollments Aggregates")
+      .config("spark.streaming.stopGracefullyOnShutdown", "true")
+      .config("spark.sql.sources.partitionOverwriteMode", "dynamic")
+      .getOrCreate()
+
+    require(spark.version >= "2.3", "Spark 2.3 is required due to dynamic partition overwrite mode")
+
+    opts.kafkaBroker.get match {
+      case Some(_) => writeStreamingAggregates(spark, opts)
+      case None => writeBatchAggregates(spark, opts)
+    }
+  }
+
+  def writeStreamingAggregates(spark: SparkSession, opts: Opts): Unit = {
+    val pings = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", opts.kafkaBroker())
+      .option("failOnDataLoss", opts.failOnDataLoss())
+      .option("kafka.max.partition.fetch.bytes", 8 * 1024 * 1024) // 8MB
+      .option("spark.streaming.kafka.consumer.cache.maxCapacity", kafkaCacheMaxCapacity)
+      .option("subscribe", kafkaTopic)
+      .option("startingOffsets", opts.startingOffsets())
+      .load()
+
+    val outputPath = opts.outputPath()
+
+    aggregate(pings.select("value"))
+      .repartition(1)
+      .writeStream
+      .queryName(queryName)
+      .format("parquet")
+      .option("path", s"${outputPath}/${outputPrefix}")
+      .option("checkpointLocation", opts.checkpointPath())
+      .partitionBy("submission_date_s3")
+      .start()
+      .awaitTermination()
+  }
+
+  def writeBatchAggregates(spark: SparkSession, opts: Opts): Unit = {
+    val from = LocalDate.parse(opts.from(), dateFormatter)
+    val to = opts.to.get match {
+      case Some(t) => LocalDate.parse(t, dateFormatter)
+      case _ => LocalDate.now.minusDays(1)
+    }
+
+    implicit val sc = spark.sparkContext
+    import spark.implicits._
+    for (offset <- 0L to ChronoUnit.DAYS.between(from, to)) {
+      val currentDate = from.plusDays(offset)
+
+      val pings = MozDataset("telemetry")
+        .where("sourceName") { case "telemetry" => true }
+        .where("docType") { case docType if allowedDocTypes.contains(docType) => true }
+        .where("appName") { case appName if allowedAppNames.contains(appName) => true }
+        .where("submissionDate") { case date if date == currentDate.format(dateFormatter) => true }
+        .records(opts.fileLimit.get)
+        .map(_.toByteArray)
+
+      val pingsDataframe = pings.toDF("value")
+
+      val outputPath = opts.outputPath()
+
+      aggregate(pingsDataframe)
+        .repartition(opts.numParquetFiles())
+        .write
+        .mode("overwrite")
+        .partitionBy("submission_date_s3")
+        .parquet(s"${outputPath}/${outputPrefix}")
+    }
+
+    if (shouldStopContextAtEnd(spark)) {
+      spark.stop()
+    }
+  }
+
+  private[streaming] def aggregate(messages: DataFrame): DataFrame = {
+
+    import messages.sparkSession.implicits._
+    import spark.sql.functions._
+
+    val events: Dataset[ExperimentEnrollmentEvent] = messages.flatMap(v => {
+      val m = Message.parseFrom(v.get(0).asInstanceOf[Array[Byte]])
+      val fields = m.fieldsAsMap
+      val docType = fields.getOrElse("docType", "").asInstanceOf[String]
+      if (!allowedDocTypes.contains(docType)) {
+        Array.empty[ExperimentEnrollmentEvent]
+      } else {
+        try {
+          val mainPing = MainPing(m)
+          mainPing.getNormandyEvents.map { e =>
+            val timestamp = mainPing.meta.normalizedTimestamp()
+            val submissionDate = Instant.ofEpochMilli(timestamp.getTime).atZone(ZoneId.of("UTC")).toLocalDate.format(dateFormatter)
+            ExperimentEnrollmentEvent(e.method, e.value, e.extra.flatMap(m => m.get("branch")), e.`object`, timestamp, submissionDate)
+          }
+        } catch {
+          // TODO: track parse errors
+          case _: Throwable => Array.empty[ExperimentEnrollmentEvent]
+        }
+      }
+    })
+
+    events
+      .withWatermark("timestamp", "1 minute")
+      .groupBy(
+        window($"timestamp", "5 minute").as("window"),
+        $"object", $"experiment_id", $"branch_id", $"submission_date_s3")
+      .agg(
+        count(when($"method" === "enroll", 1)).alias("enroll_count"),
+        count(when($"method" === "unenroll", 1)).alias("unenroll_count"))
+      .withColumn("window_start", $"window.start")
+      .withColumn("window_end", $"window.end")
+      .drop($"window")
+  }
+
+  private def shouldStopContextAtEnd(spark: SparkSession): Boolean = {
+    !spark.conf.get("spark.home").startsWith("/databricks")
+  }
+
+  case class ExperimentEnrollmentEvent(method: String, // enroll/unenroll
+                                       experiment_id: Option[String],
+                                       branch_id: Option[String],
+                                       `object`: String,
+                                       timestamp: Timestamp,
+                                       submission_date_s3: String)
+
+  private class Opts(args: Array[String]) extends ScallopConf(args) {
+    val kafkaBroker: ScallopOption[String] = opt[String](
+      "kafkaBroker",
+      descr = "Kafka broker (streaming mode only)",
+      required = false)
+    val from: ScallopOption[String] = opt[String](
+      "from",
+      descr = "Start submission date (batch mode only). Format: YYYYMMDD",
+      required = false)
+    val to: ScallopOption[String] = opt[String](
+      "to",
+      descr = "End submission date (batch mode only). Default: yesterday. Format: YYYYMMDD",
+      required = false)
+    val fileLimit: ScallopOption[Int] = opt[Int](
+      "fileLimit",
+      descr = "Max number of files to retrieve (batch mode only). Default: All files",
+      required = false)
+    val outputPath: ScallopOption[String] = opt[String](
+      "outputPath",
+      descr = "Output path",
+      required = false,
+      default = Some("/tmp/parquet"))
+    val failOnDataLoss: ScallopOption[Boolean] = opt[Boolean](
+      "failOnDataLoss",
+      descr = "Whether to fail the query when it’s possible that data is lost.")
+    val checkpointPath: ScallopOption[String] = opt[String](
+      "checkpointPath",
+      descr = "Checkpoint path (streaming mode only)",
+      required = false,
+      default = Some("/tmp/checkpoint"))
+    val startingOffsets: ScallopOption[String] = opt[String](
+      "startingOffsets",
+      descr = "Starting offsets (streaming mode only)",
+      required = false,
+      default = Some("latest"))
+    val numParquetFiles: ScallopOption[Int] = opt[Int](
+      "numParquetFiles",
+      descr = "Number of parquet files per submission_date_s3 (batch mode only)",
+      required = false,
+      default = Some(defaultNumFiles)
+    )
+
+    requireOne(kafkaBroker, from)
+    conflicts(kafkaBroker, List(from, to, numParquetFiles))
+    verify()
+  }
+
+}

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -106,8 +106,8 @@ object TestUtils {
   }
 
   // scalastyle:off methodLength
-  def generateMainMessages(size: Int, fieldsOverride: Option[Map[String, Any]]=None, timestamp: Option[Long]=None,
-                           fieldsToRemove: List[String] = List[String]()): Seq[Message] = {
+  def generateMainMessages(size: Int, fieldsOverride: Option[Map[String, Any]] = None, timestamp: Option[Long] = None,
+                           fieldsToRemove: List[String] = List[String](), customProcesses: Option[String] = None): Seq[Message] = {
     val defaultMap = Map(
       "clientId" -> "client1",
       "docType" -> "main",
@@ -206,6 +206,7 @@ object TestUtils {
              |          }
              |        }
              |      }
+             |      ${customProcesses.map("," + _).getOrElse("")}
              |    }
              |  }
              |}""".stripMargin),

--- a/src/test/scala/com/mozilla/telemetry/streaming/ExperimentEnrollmentsAggregatorTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/ExperimentEnrollmentsAggregatorTest.scala
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.streaming
+
+import java.sql.Timestamp
+import java.time.{LocalDateTime, ZoneOffset}
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types._
+import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
+
+class ExperimentEnrollmentsAggregatorTest extends FlatSpec with Matchers with GivenWhenThen with DataFrameSuiteBase {
+
+  val k = 10 //
+  val checkedColumns = Array("window_start", "window_end", "object", "experiment_id", "branch_id", "enroll_count", "unenroll_count")
+  val ExpectedWindowStart = new Timestamp(LocalDateTime.parse("2016-04-07T13:35:00").toInstant(ZoneOffset.UTC).toEpochMilli)
+  val ExpectedWindowEnd = new Timestamp(LocalDateTime.parse("2016-04-07T13:40:00").toInstant(ZoneOffset.UTC).toEpochMilli)
+  private val ExperimentA = "pref-flip-timer-speed-up-60-1443940"
+  private val ExperimentB = "pref-flip-search-composition-57-release-1413565"
+
+  override def assertDataFrameEquals(expected: DataFrame, result: DataFrame): Unit = {
+    def prepare(df: DataFrame) =
+      df.select(checkedColumns.head, checkedColumns.tail: _*)
+        .orderBy("window_start", "experiment_id", "branch_id")
+
+    super.assertDataFrameEquals(prepare(expected), prepare(result))
+  }
+
+  def prepareExpectedAggregate(rows: (String, String, Long, Long)*): DataFrame = {
+    import spark.implicits._
+    spark.sparkContext.parallelize(List[(Timestamp, Timestamp, String, String, String, Long, Long)](
+      rows.map(r => (ExpectedWindowStart, ExpectedWindowEnd, "preference_study", r._1, r._2, r._3, r._4)): _*
+    )).toDF(checkedColumns: _*)
+  }
+
+  "Experiment Enrollment Aggregator" should "aggregate enrollment events" in {
+    import spark.implicits._
+
+    Given("set of main pings with experiment enrollment events")
+    val mainPings = (
+      TestUtils.generateMainMessages(k, customProcesses = enrollmentEventJson(ExperimentA, Some("six"), enroll = true))
+        ++ TestUtils.generateMainMessages(k, customProcesses = enrollmentEventJson(ExperimentA, Some("six"), enroll = false))
+        ++ TestUtils.generateMainMessages(k, customProcesses = enrollmentEventJson(ExperimentB, Some("one"), enroll = true))
+      ).map(_.toByteArray).seq
+    val pingsDf = spark.createDataset(mainPings).toDF()
+
+    When("pings are aggregated")
+    val aggregates = ExperimentEnrollmentsAggregator.aggregate(pingsDf)
+
+    Then("resulting aggregate has expected schema")
+    val expectedSchema = StructType(List(
+      StructField("window_start", TimestampType, nullable = true),
+      StructField("window_end", TimestampType, nullable = true),
+      StructField("experiment_id", StringType, nullable = true),
+      StructField("branch_id", StringType, nullable = true),
+      StructField("object", StringType, nullable = true),
+      StructField("enroll_count", LongType, nullable = false),
+      StructField("unenroll_count", LongType, nullable = false),
+      StructField("submission_date_s3", StringType, nullable = true)
+    ))
+    aggregates.schema.fields should contain theSameElementsAs expectedSchema.fields
+
+    And("events are aggregated by experiment name and branch")
+    val expected = prepareExpectedAggregate((ExperimentA, "six", k, k), (ExperimentB, "one", k, 0))
+    assertDataFrameEquals(aggregates, expected)
+  }
+
+  it should "handle unenroll events without experiment branch" in {
+    import spark.implicits._
+
+    Given("set of main pings with experiment enrollment events and some unenroll events without the branch")
+    val mainPings = (
+      TestUtils.generateMainMessages(k, customProcesses = enrollmentEventJson(ExperimentA, Some("six"), enroll = true))
+        ++ TestUtils.generateMainMessages(k / 2, customProcesses = enrollmentEventJson(ExperimentA, Some("six"), enroll = false))
+        ++ TestUtils.generateMainMessages(k / 2, customProcesses = enrollmentEventJson(ExperimentA, None, enroll = false))
+      ).map(_.toByteArray).seq
+    val pingsDf = spark.createDataset(mainPings).toDF()
+
+    When("pings are aggregated")
+    val aggregates = ExperimentEnrollmentsAggregator.aggregate(pingsDf)
+
+    Then("events are aggregated, there is an aggregate with empty branch")
+    val expected = prepareExpectedAggregate((ExperimentA, "six", k, k / 2), (ExperimentA, null, 0, k / 2))
+    assertDataFrameEquals(aggregates, expected)
+  }
+
+  it should "ignore non-main pings and main pings without events" in {
+    import spark.implicits._
+
+    Given("a main ping with experiment enrollment events, main pings without events and a crash ping")
+    val mainPings = (
+      TestUtils.generateMainMessages(k, customProcesses = enrollmentEventJson(ExperimentA, Some("six"), enroll = true))
+        ++ TestUtils.generateMainMessages(k, customProcesses = Some(""" "dynamic": {"events": []} """))
+        ++ TestUtils.generateMainMessages(k)
+        ++ TestUtils.generateCrashMessages(k)
+      ).map(_.toByteArray).seq
+    val pingsDf = spark.createDataset(mainPings).toDF()
+
+    When("pings are aggregated")
+    val aggregates = ExperimentEnrollmentsAggregator.aggregate(pingsDf)
+
+    Then("resulting aggregate contains data from events with events")
+    val expected = prepareExpectedAggregate((ExperimentA, "six", k, 0))
+    assertDataFrameEquals(aggregates, expected)
+  }
+
+  private def enrollmentEventJson(experiment_id: String, experimentBranch: Option[String], enroll: Boolean): Option[String] = {
+    val branchKv = experimentBranch.map(b => s""" "branch": "$b" """).getOrElse("")
+    Some(
+      s"""
+         |"dynamic": {
+         |  "events": [
+         |    [554879, "normandy", "${if (enroll) "enroll" else "unenroll"}", "preference_study", "$experiment_id", {$branchKv}]
+         |  ]
+         |}
+      """.stripMargin)
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -6,14 +6,14 @@ package com.mozilla.telemetry.streaming
 import java.io.File
 import java.sql.Timestamp
 
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import com.mozilla.telemetry.streaming.TestUtils.Fennec
 import org.apache.commons.io.FileUtils
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.json4s.DefaultFormats
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers, Tag}
+import org.scalatest.{FlatSpec, Matchers, Tag}
 
-class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll {
+class TestErrorAggregator extends FlatSpec with Matchers with DataFrameSuiteBase {
 
   object DockerErrorAggregatorTag extends Tag("DockerErrorAggregatorTag")
 
@@ -27,21 +27,16 @@ class TestErrorAggregator extends FlatSpec with Matchers with BeforeAndAfterAll 
   // 2016-04-07T02:35:16.000Z
   val laterTimestamp = 1459996516000000000L
 
-  val spark = SparkSession.builder()
-    .appName("Error Aggregates")
-    .config("spark.streaming.stopGracefullyOnShutdown", "true")
-    .master("local[1]")
-    .getOrCreate()
-
-
   val streamingOutputPath = "/tmp/parquet"
   val streamingCheckpointPath = "/tmp/checkpoint"
 
-  override protected def beforeAll(): Unit = {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
     cleanupTestDirectories()
   }
 
-  override protected def afterAll(): Unit = {
+  override def afterAll(): Unit = {
+    super.beforeAll()
     cleanupTestDirectories()
   }
 

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestEventsToAmplitude.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestEventsToAmplitude.scala
@@ -11,6 +11,8 @@ import com.github.tomakehurst.wiremock.http.Request
 import com.github.tomakehurst.wiremock.matching.{EqualToJsonPattern, MatchResult, ValueMatcher}
 import com.mozilla.telemetry.pings.FocusEventPing
 import java.net.URLDecoder
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.json4s.jackson.JsonMethods._
@@ -19,7 +21,7 @@ import org.scalatest._
 
 import scala.collection.JavaConversions._
 
-class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with DataFrameSuiteBase {
 
   object DockerEventsTag extends Tag("DockerEventsTag")
 
@@ -33,12 +35,6 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
   implicit val formats = DefaultFormats
 
   val expectedTotalMsgs = TestUtils.scalarValue
-
-  val spark = SparkSession.builder()
-    .appName("Events to Amplitude")
-    .config("spark.streaming.stopGracefullyOnShutdown", "true")
-    .master("local[1]")
-    .getOrCreate()
 
   // mocked server pieces
   val path = "/httpapi"

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
@@ -5,21 +5,16 @@ package com.mozilla.telemetry.streaming
 
 import java.sql.Timestamp
 
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.apache.spark.sql.SparkSession
 import org.json4s.DefaultFormats
 import org.scalatest.{FlatSpec, Matchers}
 
-class TestExperimentsErrorAggregator extends FlatSpec with Matchers {
+class TestExperimentsErrorAggregator extends FlatSpec with Matchers with DataFrameSuiteBase {
 
   implicit val formats = DefaultFormats
   val k = TestUtils.scalarValue
   val app = TestUtils.defaultFennecApplication
-
-  val spark = SparkSession.builder()
-    .appName("Error Aggregates")
-    .config("spark.streaming.stopGracefullyOnShutdown", "true")
-    .master("local[1]")
-    .getOrCreate()
 
   "The aggregator" should "sum metrics over a set of dimensions" in {
     import spark.implicits._


### PR DESCRIPTION
This adds job for aggregating experiment uptake events.

Since `spark-testing-base` was introduced for testing this job, couple of existing tests had to be migrated to this library to avoid runtime issues.