### PR TITLE
Use single query name across all jobs for easier monitoring.

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
@@ -3,12 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.telemetry.streaming
 
-import java.sql.{Date, Timestamp}
+import java.sql.Timestamp
+
 import com.mozilla.telemetry.timeseries.SchemaBuilder
 
 object ExperimentsErrorAggregator {
+
   val outputPrefix = "experiment_error_aggregates/v1"
-  val queryName = "experiment_error_aggregates"
+  val appName = "Experiments Error Aggregates"
 
   val defaultCountHistogramErrorsSchema = (new SchemaBuilder()).build
   val defaultThresholdHistograms: Map[String, (List[String], List[Int])] = Map.empty
@@ -38,7 +40,7 @@ object ExperimentsErrorAggregator {
 
   def main(args: Array[String]): Unit = {
     ErrorAggregator.setPrefix(outputPrefix)
-    ErrorAggregator.setQueryName(queryName)
+    ErrorAggregator.setAppName(appName)
 
     ErrorAggregator.run(args,
       defaultDimensionsSchema,

--- a/src/main/scala/com/mozilla/telemetry/streaming/StreamingJobBase.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/StreamingJobBase.scala
@@ -15,7 +15,11 @@ import org.rogach.scallop.{ScallopConf, ScallopOption}
   * Base class for streaming jobs that read data from Kafka
   */
 abstract class StreamingJobBase extends Serializable {
-  val queryName: String
+
+  /**
+    * Generic query name for easy monitoring of production jobs
+    */
+  val QueryName: String = "main_query"
 
   /**
     * S3 output prefix with version number
@@ -88,4 +92,6 @@ object StreamingJobBase {
     */
   val DateFormat = "yyyyMMdd"
   val DateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DateFormat)
+
+  val TelemetryKafkaTopic = "telemetry"
 }

--- a/src/test/scala/com/mozilla/telemetry/streaming/StreamingJobBaseTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/StreamingJobBaseTest.scala
@@ -10,8 +10,6 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class StreamingJobBaseTest extends FlatSpec with Matchers {
   private val base = new StreamingJobBase {
-    override val queryName = ""
-    override val outputPrefix = ""
     override val clock: Clock = Clock.fixed(
       LocalDate.of(2018, 4, 5).atStartOfDay(ZoneId.of("UTC")).toInstant, ZoneId.of("UTC"))
   }

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestErrorAggregator.scala
@@ -282,8 +282,8 @@ class TestErrorAggregator extends FlatSpec with Matchers with DataFrameSuiteBase
   it should "correctly read from kafka" taggedAs(Kafka.DockerComposeTag, DockerErrorAggregatorTag) in {
     spark.sparkContext.setLogLevel("WARN")
 
-    Kafka.createTopic(ErrorAggregator.kafkaTopic)
-    val kafkaProducer = Kafka.makeProducer(ErrorAggregator.kafkaTopic)
+    Kafka.createTopic(StreamingJobBase.TelemetryKafkaTopic)
+    val kafkaProducer = Kafka.makeProducer(StreamingJobBase.TelemetryKafkaTopic)
 
     def send(rs: Seq[Array[Byte]]): Unit = {
       rs.foreach{ kafkaProducer.send(_, synchronous = true) }

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestEventsToAmplitude.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestEventsToAmplitude.scala
@@ -180,8 +180,8 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
   }
 
   "Events to Amplitude" should "send focus events via HTTP request" taggedAs(Kafka.DockerComposeTag, DockerEventsTag, DockerFocusEvents) in {
-    Kafka.createTopic(EventsToAmplitude.kafkaTopic)
-    val kafkaProducer = Kafka.makeProducer(EventsToAmplitude.kafkaTopic)
+    Kafka.createTopic(StreamingJobBase.TelemetryKafkaTopic)
+    val kafkaProducer = Kafka.makeProducer(StreamingJobBase.TelemetryKafkaTopic)
 
     def send(rs: Seq[Array[Byte]]): Unit = {
       rs.foreach{ kafkaProducer.send(_, synchronous = true) }
@@ -234,8 +234,8 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
   }
 
   "Events to Amplitude" should "send main ping events via HTTP request" taggedAs(Kafka.DockerComposeTag, DockerEventsTag, DockerMainEvents) in {
-    Kafka.createTopic(EventsToAmplitude.kafkaTopic)
-    val kafkaProducer = Kafka.makeProducer(EventsToAmplitude.kafkaTopic)
+    Kafka.createTopic(StreamingJobBase.TelemetryKafkaTopic)
+    val kafkaProducer = Kafka.makeProducer(StreamingJobBase.TelemetryKafkaTopic)
 
     def send(rs: Seq[Array[Byte]]): Unit = {
       rs.foreach{ kafkaProducer.send(_, synchronous = true) }

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestExperimentsErrorAggregator.scala
@@ -6,7 +6,6 @@ package com.mozilla.telemetry.streaming
 import java.sql.Timestamp
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.apache.spark.sql.SparkSession
 import org.json4s.DefaultFormats
 import org.scalatest.{FlatSpec, Matchers}
 


### PR DESCRIPTION
Spark suffixes couple of `spark.streaming` metrics with streaming query names. Datadog, which we're using for collecting metrics, doesn't allow using wildcards in metric paths for templating graphs. This makes creating templated dashboards for streaming jobs impossible if each of them uses different query name.
As a workaround, Datadog tags should be used for adding dimensions to metrics. Since our jobs run (at least for now) single queries, we can use common query name across all of them and leverage tags for identifying jobs in metrics store.