### PR TITLE
Pin an explicit version of the deploy.sh script to fetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:
-  - wget https://raw.githubusercontent.com/mozilla/telemetry-batch-view/master/deploy.sh
+  - wget https://raw.githubusercontent.com/mozilla/telemetry-batch-view/spark-2.3.0/deploy.sh
   - export JAR="target/scala-2.11/telemetry-streaming-assembly-0.1-SNAPSHOT.jar"
   - sbt assembly
   - git config --local user.name "Auto Deployer"


### PR DESCRIPTION
Telemetry-batch-view is significantly alterning the deploy.sh
script as that repo moves to CircleCI-based builds in
https://github.com/mozilla/telemetry-batch-view/pull/440

We will move this project to a similar style in a future change,
but for now we're pinning the deploy.sh url to the last tag
of t-b-v with Travis-based deploys.