### PR TITLE
Event ping events in events dataset

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/EventPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/EventPing.scala
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.pings
+
+import com.mozilla.telemetry.heka.Message
+import com.mozilla.telemetry.pings.main.Processes
+import com.mozilla.telemetry.pings.Ping.messageToPing
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.{JNothing, JValue}
+
+case class EventPingPayload(events: Map[String, JValue],
+                            lostEventsCount: Int,
+                            processStartTimestamp: Long,
+                            reason: String,
+                            sessionId: String,
+                            subsessionId: String)
+
+case class EventPing(application: Application,
+                     meta: Meta,
+                     payload: EventPingPayload)
+  extends Ping with HasEnvironment with HasApplication with SendsToAmplitude {
+  val processEventMap: Map[String, Seq[Event]] = Processes.names.map(
+    p => p -> Ping.extractEvents(payload.events.getOrElse(p, JNothing), List(Nil))
+  ).toMap
+
+  val events: Seq[Event] = processEventMap.flatMap(_._2).toSeq
+
+  def getClientId: Option[String] = meta.clientId
+
+  def sessionStart: Long = payload.processStartTimestamp
+
+  def getCreated: Option[Long] = meta.creationTimestamp.map(t => (t / 1e9).toLong)
+
+  def getLocale: Option[String] = meta.`environment.settings`.map(_.locale).flatten
+
+  def getMSStyleExperiments: Option[Map[String, String]] = {
+    val experimentsArray = getExperiments
+    experimentsArray.length match {
+      case 0 => None
+      case _ => Some(experimentsArray.flatMap {
+          case(Some(exp), Some(branch)) => Some(exp -> branch)
+          case _ =>  None
+        }.toMap)
+    }
+  }
+}
+
+
+object EventPing {
+  def apply(message: Message): EventPing = {
+    implicit val formats = DefaultFormats
+    val jsonFieldNames = List(
+      "environment.build",
+      "environment.settings",
+      "environment.system",
+      "environment.profile",
+      "environment.addons",
+      "environment.experiments"
+    )
+
+    val ping = messageToPing(message, jsonFieldNames)
+    ping.extract[EventPing]
+  }
+}
+

--- a/src/main/scala/com/mozilla/telemetry/streaming/EventPingEvents.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/EventPingEvents.scala
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.streaming
+
+import com.mozilla.telemetry.heka.{Message, Dataset => MozDataset}
+import com.mozilla.telemetry.pings.EventPing
+import com.mozilla.telemetry.streaming.StreamingJobBase.TelemetryKafkaTopic
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.rogach.scallop.ScallopOption
+
+object EventPingEvents extends StreamingJobBase {
+  override val outputPrefix = "events/v1"
+
+  val kafkaCacheMaxCapacity = 10
+
+  private val allowedDocTypes = List("event")
+  private val allowedAppNames = List("Firefox")
+
+  private class Opts(args: Array[String]) extends BaseOpts(args) {
+    val outputPath: ScallopOption[String] = opt[String](
+      "outputPath",
+      descr = "Output path",
+      required = true)
+    val failOnDataLoss: ScallopOption[Boolean] = opt[Boolean](
+      "failOnDataLoss",
+      descr = "Whether to fail the query when it’s possible that data is lost.")
+    val maxRecordsPerFile = opt[Int]("max-records-per-file",
+      descr = "Max number of rows to write to output files before splitting",
+      required = false, default = Some(10000000))
+
+    conflicts(kafkaBroker, List(from, to, maxRecordsPerFile))
+    verify()
+  }
+
+  def main(args: Array[String]): Unit = {
+    val opts = new Opts(args)
+
+    val spark = SparkSession.builder()
+      .appName("Event Ping Events")
+      .config("spark.streaming.stopGracefullyOnShutdown", "true")
+      .getOrCreate()
+
+    opts.kafkaBroker.get match {
+      case Some(_) => writeStreamingEvents(spark, opts)
+      case None => writeBatchEvents(spark, opts)
+    }
+  }
+
+  def writeStreamingEvents(spark: SparkSession, opts: EventPingEvents.Opts): Unit = {
+    val pings = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", opts.kafkaBroker())
+      .option("failOnDataLoss", opts.failOnDataLoss())
+      .option("kafka.max.partition.fetch.bytes", 8 * 1024 * 1024) // 8MB
+      .option("spark.streaming.kafka.consumer.cache.maxCapacity", kafkaCacheMaxCapacity)
+      .option("subscribe", TelemetryKafkaTopic)
+      .option("startingOffsets", opts.startingOffsets())
+      .load()
+
+    val outputPath = opts.outputPath()
+
+    explodeEvents(pings.select("value"))
+      .repartition(1)
+      .writeStream
+      .queryName(QueryName)
+      .format("parquet")
+      .option("path", s"${outputPath}/${outputPrefix}")
+      .option("checkpointLocation", opts.checkpointPath())
+      .partitionBy("submission_date_s3", "docType")
+      .start()
+      .awaitTermination()
+
+  }
+
+  def writeBatchEvents(spark: SparkSession, opts: EventPingEvents.Opts): Unit = {
+    implicit val sc = spark.sparkContext
+    import spark.implicits._
+
+    datesBetween(opts.from(), opts.to.get).foreach { currentDate =>
+      val pings = MozDataset("telemetry")
+        .where("sourceName") { case "telemetry" => true }
+        .where("docType") { case docType if allowedDocTypes.contains(docType) => true }
+        .where("appName") { case appName if allowedAppNames.contains(appName) => true }
+        .where("submissionDate") { case date if date == currentDate => true }
+        .records(opts.fileLimit.get)
+        .map(_.toByteArray)
+
+      val pingsDataframe = pings.toDF("value")
+
+      val outputPath = s"${opts.outputPath()}/${outputPrefix}/submission_date_s3=$currentDate/doc_type=event"
+
+      explodeEvents(pingsDataframe)
+        .write
+        .option("maxRecordsPerFile", opts.maxRecordsPerFile())
+        .mode("overwrite")
+        .parquet(outputPath)
+    }
+
+    spark.stop()
+  }
+
+  private[streaming] def explodeEvents(messages: DataFrame): Dataset[EventRow] = {
+    import messages.sparkSession.implicits._
+
+    messages.flatMap(v => {
+      try {
+        val m = Message.parseFrom(v.get(0).asInstanceOf[Array[Byte]])
+        val fields = m.fieldsAsMap
+        val docType = fields.getOrElse("docType", "").asInstanceOf[String]
+        if (!allowedDocTypes.contains(docType)) {
+          None
+        } else {
+          val ping = EventPing(m)
+          ping.processEventMap.flatMap { case (process, events) =>
+            events.map { e =>
+              EventRow(ping.meta.documentId.get, ping.meta.clientId.get, ping.meta.normalizedChannel, ping.meta.geoCountry,
+                ping.getLocale, ping.meta.appName, ping.meta.appVersion, ping.getOsName, ping.getOsVersion,
+                ping.payload.sessionId, ping.payload.subsessionId, ping.sessionStart,
+                (ping.meta.Timestamp / 1e9).toLong, ping.meta.sampleId.map(_.toString), ping.getMSStyleExperiments,
+                e.timestamp, e.category, e.method, e.`object`, e.value, e.extra, process)
+
+            }
+          }
+        }
+      } catch {
+        case _: Throwable => None
+      }
+    })
+  }
+
+  case class EventRow(document_id: String, client_id: String, normalized_channel: String,
+                      country: String, locale: Option[String], app_name: String, app_version: String,
+                      os: Option[String], os_version: Option[String], session_id: String, subsession_id: String,
+                      session_start_time: Long, timestamp: Long, sample_id: Option[String],
+                      experiments: Option[Map[String, String]], event_timestamp: Long, event_category: String,
+                      event_method: String, event_object: String, event_string_value: Option[String],
+                      event_map_values: Option[Map[String, String]], event_process: String)
+
+}

--- a/src/test/scala/com/mozilla/telemetry/pings/TestEventPing.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/TestEventPing.scala
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.pings
+
+import com.mozilla.telemetry.streaming.TestUtils
+import org.scalatest.{FlatSpec, Matchers}
+
+class TestEventPing extends FlatSpec with Matchers {
+  val message = TestUtils.generateEventMessages(1).head
+  val eventPing = EventPing(message)
+
+  "EventPing" should "contain event meta fields" in {
+    eventPing.payload.lostEventsCount should be (0)
+    eventPing.payload.processStartTimestamp should be (1530291900000L)
+    eventPing.payload.reason should be ("periodic")
+    eventPing.payload.sessionId should be ("dd302e9d-569b-4058-b7e8-02b2ff83522c")
+    eventPing.payload.subsessionId should be ("79a2728f-af12-4ed3-b56d-0531a03c2f26")
+  }
+
+  "EventPing" should "parse events correctly" in {
+    eventPing.events should be(Seq(
+      Event(4118829, "activity_stream", "end", "session", Some("909"),
+        Some(Map("addon_version" -> "2018.06.22.1337-8d599e17", "user_prefs" -> "63",
+          "session_id" -> "{78fe2428-15fb-4448-b517-cbb85f22def0}", "page" -> "about:newtab"))),
+      Event(4203540, "normandy", "enroll", "preference_study", Some("awesome-experiment"),
+        Some(Map("branch" -> "control", "experimentType" -> "exp"))),
+        Event(4203541, "test", "no", "string_value", None, Some(Map("hello" -> "world"))),
+        Event(4203542, "test", "no", "extras", None, None)
+    ))
+  }
+}

--- a/src/test/scala/com/mozilla/telemetry/streaming/TestEventPingEvents.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/TestEventPingEvents.scala
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.streaming
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class TestEventPingEvents extends FlatSpec with Matchers with DataFrameSuiteBase {
+  "Event Ping Events" can "explode events into dataset" in {
+    import spark.implicits._
+
+    val messageDF = spark.sparkContext.parallelize(
+      TestUtils.generateEventMessages(10).map(_.toByteArray)
+    ).toDF("value")
+
+    val results = EventPingEvents.explodeEvents(messageDF).persist
+
+    results.count should be(40)
+    results.filter("event_process = 'parent'").count == 20
+    results.filter("event_process = 'dynamic'").count == 20
+    results.first should be(
+      EventPingEvents.EventRow("an_id", "client1", "release", "IT", None, "Firefox", "42.0", Some("Linux"), Some("42"),
+        "dd302e9d-569b-4058-b7e8-02b2ff83522c", "79a2728f-af12-4ed3-b56d-0531a03c2f26", 1530291900000L, 1460036116,
+        None, Some(Map("experiment2" -> "chaos", "experiment1" -> "control")), 4118829, "activity_stream", "end",
+        "session", Some("909"),
+        Some(Map("addon_version" -> "2018.06.22.1337-8d599e17", "user_prefs" -> "63",
+          "session_id" -> "{78fe2428-15fb-4448-b517-cbb85f22def0}", "page" -> "about:newtab")), "parent"))
+  }
+
+}


### PR DESCRIPTION
The Events ping landed a few days ago in nightly, so this job writes the events coming in over the event pings into the `events` dataset (which is already partitioned by docType, how convenient!) This will be paired with an update to the main ping events job in telemetry-batch-view that updates the schema to be in line with the one laid out here (but the schema changes should be backwards-compatible so I'm opting not to bump the version.)

I plan to schedule this as a batch job for now but the job ended up here instead of in telemetry-batch-view since what I'm aiming for in Q3 is to create a streaming job that takes in both main and event pings, explodes out the events and publishes them in to a new kafka topic to be consumed by both the job that writes out the events dataset as well as jobs that send to amplitude, as well as any aggregations to be done on realtime events (e.g. experiment enrollments, etc)

One note: I tried to use the dynamic partition overwrite config in my tests and it wouldn't work -- there's something wonky going on with the write committer that I'd like to discuss when you're back (the spark logs say it worked correctly including the copy from the temp directory but the new partitions aren't there when I look.)