### PR TITLE
Devtools amplitude update

### DIFF
--- a/src/main/resources/schemas/devtoolsConfigFile.json
+++ b/src/main/resources/schemas/devtoolsConfigFile.json
@@ -1,7 +1,8 @@
 {
   "filters": {
     "docType": [
-      "main"
+      "main",
+      "event"
     ],
     "appName": [
       "Firefox"

--- a/src/main/resources/schemas/devtoolsConfigFile.json
+++ b/src/main/resources/schemas/devtoolsConfigFile.json
@@ -18,6 +18,7 @@
             "first_panel": "extra.first_panel",
             "splitconsole": "extra.splitconsole"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "open",
           "schema": {
@@ -61,6 +62,7 @@
         },
         {
           "amplitudeProperties": {},
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "close",
           "schema": {
@@ -112,6 +114,7 @@
             "cold": "extra.cold",
             "message_count": "extra.message_count"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "enter",
           "schema": {
@@ -158,6 +161,7 @@
             "next_panel": "extra.next_panel",
             "reason": "extra.reason"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "exit",
           "schema": {
@@ -209,6 +213,7 @@
             "cold": "extra.cold",
             "start_state": "extra.start_state"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "enter",
           "schema": {
@@ -255,6 +260,7 @@
             "next_panel": "extra.next_panel",
             "reason": "extra.reason"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "exit",
           "schema": {
@@ -306,6 +312,7 @@
             "cold": "extra.cold",
             "start_state": "extra.start_state"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "enter",
           "schema": {
@@ -352,6 +359,7 @@
             "next_panel": "extra.next_panel",
             "reason": "extra.reason"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "exit",
           "schema": {
@@ -403,6 +411,7 @@
             "cold": "extra.cold",
             "start_state": "extra.start_state"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "enter",
           "schema": {
@@ -449,6 +458,7 @@
             "next_panel": "extra.next_panel",
             "reason": "extra.reason"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "exit",
           "schema": {
@@ -500,6 +510,7 @@
             "cold": "extra.cold",
             "start_state": "extra.start_state"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "enter",
           "schema": {
@@ -546,6 +557,7 @@
             "next_panel": "extra.next_panel",
             "reason": "extra.reason"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "exit",
           "schema": {
@@ -597,6 +609,7 @@
             "cold": "extra.cold",
             "start_state": "extra.start_state"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "enter",
           "schema": {
@@ -643,6 +656,7 @@
             "next_panel": "extra.next_panel",
             "reason": "extra.reason"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "exit",
           "schema": {
@@ -694,6 +708,7 @@
             "cold": "extra.cold",
             "panel_name": "extra.panel_name"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "enter",
           "schema": {
@@ -740,6 +755,7 @@
             "next_panel": "extra.next_panel",
             "reason": "extra.reason"
           },
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "exit",
           "schema": {
@@ -788,6 +804,7 @@
       "events": [
         {
           "amplitudeProperties": {},
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "activate",
           "schema": {
@@ -831,6 +848,7 @@
         },
         {
           "amplitudeProperties": {},
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "deactivate",
           "schema": {
@@ -879,6 +897,7 @@
       "events": [
         {
           "amplitudeProperties": {},
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "activate",
           "schema": {
@@ -922,6 +941,7 @@
         },
         {
           "amplitudeProperties": {},
+          "sessionIdOffset": "extra.session_id",
           "description": "",
           "name": "deactivate",
           "schema": {

--- a/src/main/resources/schemas/schemaFileSchema.json
+++ b/src/main/resources/schemas/schemaFileSchema.json
@@ -144,6 +144,9 @@
                 },
                 "schema": {
                   "type": "object"
+                },
+                "sessionIdOffset": {
+                  "type": "string"
                 }
               }
             },

--- a/src/main/scala/com/mozilla/telemetry/pings/EventPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/EventPing.scala
@@ -13,7 +13,7 @@ import org.json4s.JsonAST.{JNothing, JValue}
 case class EventPing(application: Application,
                      meta: Meta,
                      payload: EventPingPayload)
-  extends Ping with HasEnvironment with HasApplication with SendsToAmplitude {
+  extends Ping with HasEnvironment with HasApplication with SendsToAmplitudeWithEnvironment {
   val processEventMap: Map[String, Seq[Event]] = Processes.names.map(
     p => p -> Ping.extractEvents(payload.events.getOrElse(p, JNothing), List(Nil))
   ).toMap

--- a/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
@@ -9,7 +9,6 @@ import com.mozilla.telemetry.heka.Message
 import com.mozilla.telemetry.pings.Ping.{SecondsPerHour, messageToPing}
 import com.mozilla.telemetry.pings.main.Processes
 import org.json4s.{DefaultFormats, JNothing, JValue, _}
-import org.json4s.JsonDSL._
 
 import scala.util.{Success, Try}
 
@@ -18,7 +17,7 @@ case class MainPing(application: Application,
                     // Environment omitted because it's mostly available under meta
                     meta: Meta,
                     payload: MainPingPayload
-                   ) extends Ping with HasEnvironment with HasApplication with SendsToAmplitude {
+                   ) extends Ping with HasEnvironment with HasApplication with SendsToAmplitudeWithEnvironment {
   def getCountHistogramValue(histogram_name: String): Option[Int] = {
     try {
       this.meta.`payload.histograms` \ histogram_name \ "values" \ "0" match {
@@ -119,21 +118,6 @@ case class MainPing(application: Application,
     case JString(d) => OffsetDateTime.parse(d).toEpochSecond * 1000
     // sessionStartDate is truncated to the hour anyway, so we just want to get somewhere near the correct timeframe
     case _ => ((meta.Timestamp / 1e9) - events.map(_.timestamp).max).toLong
-  }
-
-  override def pingAmplitudeProperties: JObject = {
-    val experimentsArray = getExperiments.flatMap {
-      case (Some(exp), Some(branch)) => Some(s"${exp}_$branch")
-      case _ => None
-    }.toSeq
-
-    ("user_properties" ->
-      ("channel" -> meta.normalizedChannel) ~
-      ("app_build_id" -> meta.appBuildId) ~
-      ("locale" -> meta.`environment.settings`.map(_.locale)) ~
-      ("is_default_browser" -> meta.`environment.settings`.map(_.isDefaultBrowser)) ~
-      ("experiments" -> experimentsArray)) ~
-      ("user_id" -> getClientId)
   }
 }
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/EventsToAmplitude.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/EventsToAmplitude.scala
@@ -94,6 +94,7 @@ object EventsToAmplitude extends StreamingJobBase {
   case class AmplitudeEvent(
     name: String,
     description: String,
+    sessionIdOffset: Option[String],
     amplitudeProperties: Option[Map[String, String]],
     userProperties: Option[Map[String, String]],
     schema: JValue)

--- a/src/test/resources/testMainPingConfigFile.json
+++ b/src/test/resources/testMainPingConfigFile.json
@@ -1,7 +1,8 @@
 {
   "filters": {
     "docType": [
-      "main"
+      "main",
+      "event"
     ],
     "appName": [
       "Firefox"
@@ -96,6 +97,7 @@
       "events": [
         {
           "name": "AppClose",
+          "sessionIdOffset": "extra.session_id",
           "description": "User closing the app",
           "amplitudeProperties": {
             "session_length": "extra.sessionLength"


### PR DESCRIPTION
Requesting review from @jklukas since he'll be looking into adding the schema file and running the job to take care of Savant events

This PR does two things:
- Add support for the Event ping in EventsToAmplitude
- Add the concept of a sessionIdOffset to the amplitude event schema, since devtools needs a separate session_id for each time the devtools toolbox was opened (including when there are multiple toolboxes open) to really make sense of their event data