### PR TITLE
Enforce warning-free compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,8 +77,10 @@ javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSC
 parallelExecution in Test := false
 
 scalacOptions ++= Seq(
+  "-feature",
   "-Ywarn-unused",
-  "-Ywarn-unused-import"
+  "-Ywarn-unused-import",
+  "-Xfatal-warnings"
 )
 
 assemblyMergeStrategy in assembly := {

--- a/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
@@ -104,8 +104,6 @@ case class MainPing(application: Application,
   }
 
   def getNormandyEvents: Seq[Event] = {
-    implicit val formats = org.json4s.DefaultFormats
-
     val dynamicProcessEvents = Ping.extractEvents(this.payload.processes, List("dynamic" :: "events" :: Nil))
     dynamicProcessEvents.filter(_.category == "normandy")
   }

--- a/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
@@ -340,7 +340,6 @@ trait SendsToAmplitude {
 
 object SendsToAmplitude {
   def apply(message: Message): SendsToAmplitude = {
-    implicit val formats = DefaultFormats
     message.fieldsAsMap.get("docType") match {
       case Some("focus-event") => FocusEventPing(message)
       case Some("main") => MainPing(message)

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -4,16 +4,16 @@
 package com.mozilla.telemetry.streaming
 
 import java.sql.Timestamp
-import com.mozilla.telemetry.streaming.StreamingJobBase.TelemetryKafkaTopic
+
 import com.mozilla.telemetry.heka.{Dataset, Message}
 import com.mozilla.telemetry.pings._
+import com.mozilla.telemetry.streaming.StreamingJobBase.TelemetryKafkaTopic
 import com.mozilla.telemetry.timeseries._
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.functions.{col, sum, window}
 import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.joda.time.{DateTime, Days, LocalDateTime, format}
-import org.json4s._
 import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 object ErrorAggregator {
@@ -244,8 +244,6 @@ object ErrorAggregator {
   }
 
   def parsePing(dimensions: StructType, statsSchema: StructType, countHistograms: StructType)(message: Message): Array[Row] = {
-    implicit val formats = DefaultFormats
-
     val fields = message.fieldsAsMap
     val docType = fields.getOrElse("docType", "").asInstanceOf[String]
     if (!allowedDocTypes.contains(docType)) {

--- a/src/main/scala/com/mozilla/telemetry/streaming/EventsToAmplitude.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/EventsToAmplitude.scala
@@ -122,8 +122,6 @@ object EventsToAmplitude extends StreamingJobBase {
   }
 
   def parsePing(message: Message, sample: Double, config: Config): Array[String] = {
-    implicit val formats = DefaultFormats
-
     val emptyReturn = Array[String]()
     val fields = message.fieldsAsMap
 


### PR DESCRIPTION
This fixes all remaining compiler warnings and requires warning-free builds from now on.