### PR TITLE
Use consistent naming across test classes

### DIFF
--- a/src/test/scala/com/mozilla/telemetry/pings/EventPingTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/EventPingTest.scala
@@ -6,7 +6,7 @@ package com.mozilla.telemetry.pings
 import com.mozilla.telemetry.streaming.TestUtils
 import org.scalatest.{FlatSpec, Matchers}
 
-class TestEventPing extends FlatSpec with Matchers {
+class EventPingTest extends FlatSpec with Matchers {
   val message = TestUtils.generateEventMessages(1).head
   val eventPing = EventPing(message)
 

--- a/src/test/scala/com/mozilla/telemetry/pings/FocusEventPingTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/FocusEventPingTest.scala
@@ -8,7 +8,7 @@ import com.mozilla.telemetry.streaming.EventsToAmplitude.Config
 import org.scalatest.{FlatSpec, Matchers}
 
 
-class TestFocusEventPing extends FlatSpec with Matchers{
+class FocusEventPingTest extends FlatSpec with Matchers{
   val message = TestUtils.generateFocusEventMessages(1).head
   val ping = SendsToAmplitude(message)
   val ts = TestUtils.testTimestampMillis

--- a/src/test/scala/com/mozilla/telemetry/pings/PingsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/PingsTest.scala
@@ -6,11 +6,11 @@ package com.mozilla.telemetry.streaming
 import java.sql.Timestamp
 
 import com.mozilla.telemetry.pings._
-import com.mozilla.telemetry.streaming.TestEventsToAmplitude.CustomMainPingPayload
+import com.mozilla.telemetry.streaming.EventsToAmplitudeTest.CustomMainPingPayload
 import org.scalatest.{FlatSpec, Matchers}
 
 
-class TestPings extends FlatSpec with Matchers{
+class PingsTest extends FlatSpec with Matchers{
 
   val ContentHistogramPayload = Some(
     """

--- a/src/test/scala/com/mozilla/telemetry/sinks/HTTPSinkTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/sinks/HTTPSinkTest.scala
@@ -14,7 +14,7 @@ import org.scalatest._
 
 import scala.annotation.tailrec
 
-class TestHTTPSink extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+class HTTPSinkTest extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
   val Port = 9876
   val Host = "localhost"
   val Path = "/httpapi"

--- a/src/test/scala/com/mozilla/telemetry/streaming/ErrorAggregatorTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/ErrorAggregatorTest.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.json4s.DefaultFormats
 import org.scalatest.{FlatSpec, Matchers, Tag}
 
-class TestErrorAggregator extends FlatSpec with Matchers with DataFrameSuiteBase {
+class ErrorAggregatorTest extends FlatSpec with Matchers with DataFrameSuiteBase {
 
   object DockerErrorAggregatorTag extends Tag("DockerErrorAggregatorTag")
 

--- a/src/test/scala/com/mozilla/telemetry/streaming/EventPingEventsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/EventPingEventsTest.scala
@@ -7,7 +7,7 @@ import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.scalatest.{FlatSpec, Matchers}
 
 
-class TestEventPingEvents extends FlatSpec with Matchers with DataFrameSuiteBase {
+class EventPingEventsTest extends FlatSpec with Matchers with DataFrameSuiteBase {
   "Event Ping Events" can "explode events into dataset" in {
     import spark.implicits._
 

--- a/src/test/scala/com/mozilla/telemetry/streaming/EventsToAmplitudeTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/EventsToAmplitudeTest.scala
@@ -19,7 +19,7 @@ import org.json4s.jackson.JsonMethods._
 import org.json4s.{DefaultFormats, _}
 import org.scalatest._
 
-class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with DataFrameSuiteBase {
+class EventsToAmplitudeTest extends FlatSpec with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with DataFrameSuiteBase {
 
   object DockerEventsTag extends Tag("DockerEventsTag")
   object DockerFocusEvents extends Tag("DockerFocusEvents")
@@ -171,7 +171,7 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
   "HTTPSink" should "send main ping events correctly" in {
     val config = EventsToAmplitude.readConfigFile(configFilePath(MainEventsConfigFile))
     val msgs = TestUtils.generateMainMessages(expectedTotalMsgs,
-      customPayload=TestEventsToAmplitude.CustomMainPingPayload)
+      customPayload=EventsToAmplitudeTest.CustomMainPingPayload)
     val sink = new sinks.HttpSink(s"http://$Host:$Port$path", Map("api_key" -> apiKey))()
 
     msgs.foreach(m => sink.process(SendsToAmplitude(m).getAmplitudeEvents(config).get))
@@ -190,7 +190,7 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
 
     // should ignore main messages
     val messages = (TestUtils.generateFocusEventMessages(expectedTotalMsgs)
-      ++ TestUtils.generateMainMessages(expectedTotalMsgs, customPayload=TestEventsToAmplitude.CustomMainPingPayload))
+      ++ TestUtils.generateMainMessages(expectedTotalMsgs, customPayload=EventsToAmplitudeTest.CustomMainPingPayload))
       .map(_.toByteArray)
 
     val listener = new StreamingQueryListener {
@@ -243,7 +243,7 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
     }
 
     val messages = (TestUtils.generateFocusEventMessages(expectedTotalMsgs)
-      ++ TestUtils.generateMainMessages(expectedTotalMsgs, customPayload=TestEventsToAmplitude.CustomMainPingPayload))
+      ++ TestUtils.generateMainMessages(expectedTotalMsgs, customPayload=EventsToAmplitudeTest.CustomMainPingPayload))
       .map(_.toByteArray) // should ignore focus event messages
 
     val listener = new StreamingQueryListener {
@@ -340,7 +340,7 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
   "Session Id offset field" should "be added to session id when present" in {
     val config = EventsToAmplitude.readConfigFile(configFilePath(MainEventsConfigFile))
     val msg = TestUtils.generateMainMessages(1,
-      customPayload=TestEventsToAmplitude.sessionIdOffsetPayload).head
+      customPayload=EventsToAmplitudeTest.sessionIdOffsetPayload).head
 
     val res = for {
       JObject(l) <- parse(SendsToAmplitude(msg).getAmplitudeEvents(config).get) \\ "session_id"
@@ -351,7 +351,7 @@ class TestEventsToAmplitude extends FlatSpec with Matchers with BeforeAndAfterAl
   }
 }
 
-object TestEventsToAmplitude {
+object EventsToAmplitudeTest {
   val CustomMainPingPayload = Some(
     """
       |    "processes": {

--- a/src/test/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregatorTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregatorTest.scala
@@ -9,7 +9,7 @@ import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.json4s.DefaultFormats
 import org.scalatest.{FlatSpec, Matchers}
 
-class TestExperimentsErrorAggregator extends FlatSpec with Matchers with DataFrameSuiteBase {
+class ExperimentsErrorAggregatorTest extends FlatSpec with Matchers with DataFrameSuiteBase {
 
   implicit val formats = DefaultFormats
   val k = TestUtils.scalarValue


### PR DESCRIPTION
This makes test naming consistent in this repository by renaming some test classes to use ".+Test" pattern, similar as in https://github.com/mozilla/telemetry-batch-view
