### PR TITLE
Bug 1476789 - Add channel option to ErrorAggregator

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -54,7 +54,7 @@ object ErrorAggregator {
       required = false)
     val channel: ScallopOption[String] = opt[String](
       "channel",
-      descr = "Only process data from the given channel",
+      descr = "Only process data from the given channel (batch mode only)",
       required = false)
     val outputPath: ScallopOption[String] = opt[String](
       "outputPath",
@@ -85,7 +85,7 @@ object ErrorAggregator {
       )
 
     requireOne(kafkaBroker, from)
-    conflicts(kafkaBroker, List(from, to, fileLimit, numParquetFiles))
+    conflicts(kafkaBroker, List(from, to, fileLimit, channel, numParquetFiles))
     verify()
   }
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1476789)

The `experiments_error_aggregates` job in airflow is a dependency of the `experiments_aggregates` job in the `main_summary` DAG. I'm currently setting the channel to nightly in the MainSummaryView when the deploy environment is `dev`. 

This PR exposes an option to set a channel to filter in the options. I also set the `minPartitions` option in `Dataset.records` so that the job finishes in a reasonable amount of time on a single machine. I think this should work out on the current production settings.

In order to avoid spilling, the partitions should be roughly this size: 
`size(partition) <= memory * spark.memory.fraction / spark.default.parallelism`
or roughly `~30GB * 0.6 / 32 <= 562.5 MB` with c3.x4large nodes.

With our current settings, we should be able to fit around 1.4TB of data without spilling into disk on batch mode.

`562.5MB * 20 nodes * 32 executors * 4 = 1.44TB >= size(Dataset)`

I've tested that the current behavior is unchanged and that the new behavior is suitable for testing.

```
date="20180701"

spark-submit --master yarn \
             --deploy-mode client \
             --class com.mozilla.telemetry.streaming.ExperimentsErrorAggregator \
             telemetry-streaming-assembly-0.1-SNAPSHOT.jar \
             --outputPath "s3://telemetry-test-bucket" \
             --numParquetFiles 6 \
             --from $date \
             --to $date
             --channel nightly

aws s3 ls s3://telemetry-test-bucket/experiment_error_aggregates/v1/submission_date_s3=20180701/ --summarize --human-readable
2018-07-18 15:29:33  200.5 KiB part-00000-ef15f220-7199-4aad-92f6-effbff17e187.c000.snappy.parquet
2018-07-18 15:29:33  201.8 KiB part-00001-ef15f220-7199-4aad-92f6-effbff17e187.c000.snappy.parquet
2018-07-18 15:29:33  201.7 KiB part-00002-ef15f220-7199-4aad-92f6-effbff17e187.c000.snappy.parquet
2018-07-18 15:29:33  202.1 KiB part-00003-ef15f220-7199-4aad-92f6-effbff17e187.c000.snappy.parquet
2018-07-18 15:29:33  202.6 KiB part-00004-ef15f220-7199-4aad-92f6-effbff17e187.c000.snappy.parquet
2018-07-18 15:29:33  200.2 KiB part-00005-ef15f220-7199-4aad-92f6-effbff17e187.c000.snappy.parquet

Total Objects: 6
   Total Size: 1.2 MiB
```
