### PR TITLE
Bug 1474987 Add pipeline for Savant events to Amplitude

### DIFF
--- a/configs/desktop_savant_events_schemas.json
+++ b/configs/desktop_savant_events_schemas.json
@@ -1015,7 +1015,7 @@
                   "pwmgr"
                 ]
               },
-              "value": {
+              "object": {
                 "type": "string",
                 "enum": [
                   "ask"
@@ -1026,7 +1026,7 @@
               "timestamp",
               "category",
               "method",
-              "value"
+              "object"
             ]
           }
         },
@@ -1058,7 +1058,7 @@
                   "pwmgr"
                 ]
               },
-              "value": {
+              "object": {
                 "type": "string",
                 "enum": [
                   "save"
@@ -1069,7 +1069,7 @@
               "timestamp",
               "category",
               "method",
-              "value"
+              "object"
             ]
           }
         },
@@ -1101,7 +1101,7 @@
                   "pwmgr"
                 ]
               },
-              "value": {
+              "object": {
                 "type": "string",
                 "enum": [
                   "update"
@@ -1112,7 +1112,7 @@
               "timestamp",
               "category",
               "method",
-              "value"
+              "object"
             ]
           }
         },

--- a/configs/desktop_savant_events_schemas.json
+++ b/configs/desktop_savant_events_schemas.json
@@ -1,0 +1,1157 @@
+{
+  "source": "telemetry-cohorts",
+  "filters": {
+    "docType": [
+      "main"
+    ],
+    "appName": [
+      "Firefox"
+    ],
+    "experimentId": [
+      "pref-flip-savant-1457226-de-existing-users",
+      "pref-flip-savant-1457226-de-new-users",
+      "pref-flip-savant-1457226-en-existing-users",
+      "pref-flip-savant-1457226-en-new-users"
+    ]
+  },
+  "eventGroups": [
+    {
+      "eventGroupName": "SAVANT",
+      "events": [
+        {
+          "name": "open bookmark",
+          "description": "client opens a bookmark",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.navigate",
+            "meta-cat-2": "literal.bookmark"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "follow_bookmark"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "open"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "save bookmark",
+          "description": "client saves a bookmark",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.bookmark"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "bookmark"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "save"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "remove bookmark",
+          "description": "client removes a bookmark",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.bookmark"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "bookmark"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "remove"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "open hamburger menu",
+          "description": "client opens the hamburger menu",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "hamburger_menu"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "open"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "open library menu",
+          "description": "client opens the library menu",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "library_menu"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "open"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "open dotdotdot menu",
+          "description": "client opens the dotdotdot menu",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "dotdotdot_menu"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "open"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "on readermode",
+          "description": "Client turns on reader mode",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.readermode"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "readermode"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "on"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "off readermode",
+          "description": "Client turns off reader mode",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.readermode"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "readermode"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "off"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "open tab",
+          "description": "Client opens a new tab",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.frame",
+            "meta-cat-2": "literal.tab"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "tab"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "open"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "close tab",
+          "description": "Client closes a new tab",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.frame",
+            "meta-cat-2": "literal.tab"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "tab"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "close"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "select tab",
+          "description": "Client selects a tab",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.frame",
+            "meta-cat-2": "literal.tab"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "tab"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "select"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "follow bookmark url",
+          "description": "Client selects suggestion from URL bar which is a bookmark",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.navigate",
+            "meta-cat-2": "literal.url_bar"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "follow_urlbar_link"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "bookmark"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "follow history url",
+          "description": "Client selects suggestion from URL bar which is a history",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.navigate",
+            "meta-cat-2": "literal.url_bar"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "follow_urlbar_link"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "history"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "made search",
+          "description": "Client makes a search",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.navigate",
+            "entrypoint": "object",
+            "type": "value",
+            "engine": "extra.engine"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "search"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method"
+            ]
+          }
+        },
+        {
+          "name": "enable addon",
+          "description": "Client enables an already installed addon",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.addon",
+            "addonid": "value"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "addon"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "enable"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "disable addon",
+          "description": "Client disable an already installed addon",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.addon",
+            "addonid": "value"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "addon"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "disable"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "install addon start",
+          "description": "Client starts installing an addon",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.addon",
+            "addonid": "value"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "addon"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "install_start"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "install addon finish",
+          "description": "Addon client started installing finishes installing",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.addon",
+            "addonid": "value"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "addon"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "install_finish"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "remove addon start",
+          "description": "Client starts removing an addon",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.addon",
+            "addonid": "value"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "addon"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "remove_start"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "remove addon finish",
+          "description": "Addon client started removing finishes un-installing",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.addon",
+            "addonid": "value"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "addon"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "remove_finish"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "load login form",
+          "description": "Client loads a page with a login form",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.encounter",
+            "meta-cat-2": "literal.loginform",
+            "can-record-submit": "extra.canRecordSubmit",
+            "flow-id": "extra.flow_id"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "login_form"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "load"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "submit login form",
+          "description": "Client submits credentials to a login form",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.encounter",
+            "meta-cat-2": "literal.loginform",
+            "flow-id": "extra.flow_id"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "login_form"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "submit"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "use pw manager",
+          "description": "client uses pw from the client manager",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.pwmgr",
+            "flow-id": "extra.flow_id"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "pwmgr_use"
+                ]
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "use"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "object"
+            ]
+          }
+        },
+        {
+          "name": "asked add pw",
+          "description": "browser asks client if they want to save or update a password used",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.popup",
+            "meta-cat-2": "literal.pwmgr",
+            "add-type": "value",
+            "flow-id": "extra.flow_id"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "pwmgr"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "enum": [
+                  "ask"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "value"
+            ]
+          }
+        },
+        {
+          "name": "saved pw",
+          "description": "client saves a password after being prompted",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.pwmgr",
+            "flow-id": "extra.flow_id"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "pwmgr"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "enum": [
+                  "save"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "value"
+            ]
+          }
+        },
+        {
+          "name": "updated pw",
+          "description": "client updates pw after being prompted",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.feature",
+            "meta-cat-2": "literal.pwmgr",
+            "flow-id": "extra.flow_id"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "pwmgr"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "enum": [
+                  "update"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method",
+              "value"
+            ]
+          }
+        },
+        {
+          "name": "study ended",
+          "description": "client is unenrolled from the experiment",
+          "amplitudeProperties": {
+            "meta-cat-1": "literal.shield",
+            "reason": "object"
+          },
+          "schema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number",
+                "minimum": 0
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "savant"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "end_study"
+                ]
+              }
+            },
+            "required": [
+              "timestamp",
+              "category",
+              "method"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/configs/focus_android_events_schemas.json
+++ b/configs/focus_android_events_schemas.json
@@ -1,5 +1,6 @@
 {
-    "eventGroupName": "Focus", 
+    "source": "telemetry",
+    "eventGroupName": "Focus",
     "events": [
         [
             {

--- a/src/main/resources/schemas/devtoolsConfigFile.json
+++ b/src/main/resources/schemas/devtoolsConfigFile.json
@@ -1,4 +1,5 @@
 {
+  "source": "telemetry",
   "filters": {
     "docType": [
       "main",

--- a/src/main/resources/schemas/schemaFileSchema.json
+++ b/src/main/resources/schemas/schemaFileSchema.json
@@ -46,6 +46,9 @@
     }
   },
   "properties": {
+    "source": {
+      "type": "string"
+    },
     "filters": {
       "type": "object",
       "properties": {

--- a/src/main/resources/schemas/simpleFocusConfigFile.json
+++ b/src/main/resources/schemas/simpleFocusConfigFile.json
@@ -1,4 +1,5 @@
 {
+  "source": "telemetry",
   "filters": {
     "docType": [
       "focus-event"

--- a/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
@@ -387,8 +387,9 @@ case class Event(timestamp: Int,
     case "category" => category
     case "method" => method
     case "object" => `object`
-    case "value" => value.getOrElse ("")
-    case e if e.startsWith ("extra") => extra.getOrElse (Map.empty).getOrElse (e.stripPrefix ("extra."), "")
+    case "value" => value.getOrElse("")
+    case _ if field.startsWith("extra.") => extra.getOrElse(Map.empty).getOrElse(field.stripPrefix ("extra."), "")
+    case _ if field.startsWith("literal.") => field.stripPrefix("literal.")
     case _ => ""
   }
 

--- a/src/test/resources/testConfigFile.json
+++ b/src/test/resources/testConfigFile.json
@@ -1,4 +1,5 @@
 {
+  "source": "telemetry",
   "filters": {
     "docType": [
       "focus-event"
@@ -53,7 +54,8 @@
           "name": "Erase",
           "description": "",
           "amplitudeProperties": {
-            "erase_object": "value"
+            "erase_object": "value",
+            "literal_field": "literal.literal value"
           },
           "userProperties": {
             "host": "extra.host"

--- a/src/test/resources/testMainPingConfigFile.json
+++ b/src/test/resources/testMainPingConfigFile.json
@@ -1,4 +1,5 @@
 {
+  "source": "telemetry",
   "filters": {
     "docType": [
       "main",
@@ -54,7 +55,8 @@
           "name": "Erase",
           "description": "",
           "amplitudeProperties": {
-            "erase_object": "value"
+            "erase_object": "value",
+            "literal_field": "literal.literal value"
           },
           "userProperties": {
             "host": "extra.host"

--- a/src/test/scala/com/mozilla/telemetry/pings/FocusEventPingTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/FocusEventPingTest.scala
@@ -18,7 +18,7 @@ class FocusEventPingTest extends FlatSpec with Matchers{
   }
 
   it can "correctly sample itself" in {
-    val noFilters = Config(Map.empty, Nil)
+    val noFilters = Config("telemetry", Map.empty, Nil)
 
     ping.includePing(0.0, noFilters) should be (false)
     ping.includePing(0.72, noFilters) should be (false)
@@ -27,22 +27,22 @@ class FocusEventPingTest extends FlatSpec with Matchers{
   }
 
   it can "correctly filter itself" in {
-    val notIncluded = Config(Map("os" -> List("iOS")), Nil)
+    val notIncluded = Config("telemetry", Map("os" -> List("iOS")), Nil)
     ping.includePing(1.0, notIncluded) should be (false)
   }
 
   it can "correctly include itself" in {
-    val included = Config(Map("os" -> List("Android")), Nil)
+    val included = Config("telemetry", Map("os" -> List("Android")), Nil)
     ping.includePing(1.0, included) should be (true)
   }
 
   it can "throw on non-existent properties in filter" in {
-    val included = Config(Map("nonexistent" -> List("Android")), Nil)
+    val included = Config("telemetry", Map("nonexistent" -> List("Android")), Nil)
     an [NoSuchElementException] should be thrownBy ping.includePing(1.0, included) // scalastyle:ignore
   }
 
   it can "filter on non-string properties" in {
-    val included = Config(Map("created" -> List("1506024685632")), Nil)
+    val included = Config("telemetry", Map("created" -> List("1506024685632")), Nil)
     ping.includePing(1.0, included) should be (true)
   }
 }

--- a/src/test/scala/com/mozilla/telemetry/streaming/EventsToAmplitudeTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/EventsToAmplitudeTest.scala
@@ -87,8 +87,27 @@ class EventsToAmplitudeTest extends FlatSpec with Matchers with BeforeAndAfterAl
   // specific events we expect to see
   private def eventsJson(eventGroup: String) =
     s"""{ "event_type": "$eventGroup - AppOpen" }""" ::
-    s"""{ "event_type": "$eventGroup - Erase", "event_properties": { "erase_object": "erase_home" }, "user_properties": { "host": "side" }}""" ::
-    s"""{ "event_type": "second_event_group - AppClose", "event_properties": { "session_length": "1000" }}""" :: Nil
+    s"""
+      |{
+      |   "user_properties" : {
+      |      "host" : "side"
+      |   },
+      |   "event_properties" : {
+      |      "literal_field" : "literal value",
+      |      "erase_object" : "erase_home"
+      |   },
+      |   "event_type" : "$eventGroup - Erase"
+      |}
+      """.stripMargin ::
+    s"""
+       |{
+       |   "event_type" : "second_event_group - AppClose",
+       |   "event_properties" : {
+       |      "session_length" : "1000"
+       |   }
+       |}
+      """.stripMargin ::
+    Nil
 
   private val focusEventJsonMatch = JArray(
       eventsJson("m_foc").map{
@@ -348,6 +367,11 @@ class EventsToAmplitudeTest extends FlatSpec with Matchers with BeforeAndAfterAl
     } yield session_id
 
     res should contain only (1527696000000L, 1527696002000L)
+  }
+
+  "Schema configs" should "be parseable" in {
+    EventsToAmplitude.readConfigFile("configs/focus_android_events_schemas.json")
+    EventsToAmplitude.readConfigFile("configs/desktop_savant_events_schemas.json")
   }
 }
 


### PR DESCRIPTION
This adds the JSON file to support Savant event mappings and adds a few new features to support those mappings.

First, we now support literal fields. Values enclosed in single quotes will output the literal value rather than looking up the property in the event.

Second, we now support dataset sources other than "telemetry".