### PR TITLE
Add buildId to crash ping tags

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/CrashPingStreamingBase.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/CrashPingStreamingBase.scala
@@ -215,6 +215,7 @@ abstract class CrashPingStreamingBase extends StreamingJobBase {
           "osName" -> ping.getOsName.getOrElse(""),
           "osVersion" -> ping.getOsVersion.getOrElse(""),
           "architecture" -> ping.getArchitecture.getOrElse(""),
+          "buildIdTag" -> ping.getNormalizedBuildId.getOrElse(metadata.appBuildId),
           "crashSignature" -> crashSignature
         ).filter{ case (k, v) => v.nonEmpty }
 


### PR DESCRIPTION
I just realized buildId is the only way to differentiate nightly 😖