### PR TITLE
Bug 1482924 Use active_ticks scalar rather than simpleMeasurement

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/MainPing.scala
@@ -171,9 +171,15 @@ case class MainPing(application: Application,
     case _ => 0
   }
 
-  def activeTicks: Option[Long] = meta.`payload.simpleMeasurements` \ "activeTicks" match {
-    case JInt(v) => Some(v.toLong)
-    case _ => None
+  def activeTicks: Option[Long] = {
+    // Prefer the scalar over the simpleMeasurement due to bug through at least FF 61;
+    // See bug 1482924
+    getScalarValue("parent", "browser.engagement.active_ticks")
+      .orElse(
+        meta.`payload.simpleMeasurements` \ "activeTicks" match {
+          case JInt(v) => Some(v.toLong)
+          case _ => None
+        })
   }
 
   def reason: Option[String] = meta.`payload.info` \ "reason" match {

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -205,7 +205,7 @@ object TestUtils {
       "payload.simpleMeasurements" ->
         """
           |{
-          |  "activeTicks": 2000,
+          |  "activeTicks": 275,
           |  "firstPaint": 1200
           |}
         """.stripMargin,

--- a/src/test/scala/com/mozilla/telemetry/streaming/EventsToAmplitudeTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/EventsToAmplitudeTest.scala
@@ -96,7 +96,7 @@ class EventsToAmplitudeTest extends FlatSpec with Matchers with BeforeAndAfterAl
        |  "event_type": "Meta - session split",
        |  "event_properties": {
        |    "subsession_length": "3600",
-       |    "active_ticks": "2000",
+       |    "active_ticks": "271",
        |    "uri_count": "63",
        |    "search_count": "4"
        |  }


### PR DESCRIPTION
The simpleMeasurement version of activeTicks is sometimes inflated.

We will need to backfill the Savant project in Amplitude using this updated logic.