### PR TITLE
Bug 1482924 Change session split event name for backfill

### DIFF
--- a/configs/desktop_savant_events_schemas.json
+++ b/configs/desktop_savant_events_schemas.json
@@ -16,7 +16,7 @@
       "eventGroupName": "Meta",
       "events": [
         {
-          "name": "session split",
+          "name": "session split v2",
           "description": "a ping was sent defining a subsession",
           "amplitudeProperties": {
             "subsession_length": "extra.subsession_length",


### PR DESCRIPTION
As discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1482924
we want to backfill just session split events in order to pick up the
new active-ticks logic. We can only accomplish that in Amplitude
by sending events with a different name.

Once this is merged, I'll proceed with backfilling.