### PR TITLE
Bug 1482924 Add event name to insert_id

### DIFF
--- a/configs/desktop_savant_events_schemas.json
+++ b/configs/desktop_savant_events_schemas.json
@@ -16,7 +16,7 @@
       "eventGroupName": "Meta",
       "events": [
         {
-          "name": "session split v2",
+          "name": "session split v3",
           "description": "a ping was sent defining a subsession",
           "amplitudeProperties": {
             "subsession_length": "extra.subsession_length",


### PR DESCRIPTION
The "Meta - session split v2" events we backfilled were
rejected for recent days due to having identical insert_id
to the v1 events.

We change the logic so that future event name changes will
not get deduplicated, and we bump the session split event name again.

This time, I'll backfill and verify _before_ merging the PR in case
we encounter another hiccup.