### PR TITLE
Bug 1484819 Support Amplitude /batch endpoint; partition data

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import com.mozilla.telemetry.heka.Message
 import com.mozilla.telemetry.pings.Meta._
-import com.mozilla.telemetry.streaming.EventsToAmplitude.{AmplitudeEvent, Config}
+import com.mozilla.telemetry.streaming.EventsToAmplitude.{AmplitudeEvent, Config, KeyedAmplitudePayload}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods.{parse, _}
 import org.json4s.{DefaultFormats, Extraction, JArray, JField, JNull, JObject, JValue, _}
@@ -346,7 +346,7 @@ trait SendsToAmplitude {
       ("city" -> meta.geoCity)
   }
 
-  def getAmplitudeEvents(config: Config): Option[String] = {
+  def getAmplitudeEvents(config: Config): Option[KeyedAmplitudePayload] = {
     implicit val formats = DefaultFormats
 
     val factory = JsonSchemaFactory.byDefault
@@ -366,7 +366,8 @@ trait SendsToAmplitude {
     if (eventsList.isEmpty) {
       None
     } else {
-      Some(compact(render(eventsList)))
+      val events = eventsList.map(e => compact(render(e)))
+      Some(KeyedAmplitudePayload(getClientId.getOrElse(""), events))
     }
   }
 

--- a/src/main/scala/com/mozilla/telemetry/sinks/AmplitudeBatchHttpSink.scala
+++ b/src/main/scala/com/mozilla/telemetry/sinks/AmplitudeBatchHttpSink.scala
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.sinks
+
+import scalaj.http.HttpRequest
+
+import scala.collection.AbstractIterator
+
+case class AmplitudeBatchHttpSink(
+  apiKey: String,
+  url: String = "https://api.amplitude.com/batch",
+  maxEventsPerBatch: Int = 2000,  // Amplitude will return a 413 for more than 2000 events.
+  maxBytesPerBatch: Int = 10 * 1024 * 1024,  // 10 MB, half of the API's 20 MB payload limit.
+  maxAttempts: Int = Int.MaxValue,
+  defaultDelayMillis: Int = 500,
+  maxDelayMillis: Int = 30000,
+  connectionTimeoutMillis: Int = 2000,
+  readTimeoutMillis: Int = 5000
+) extends HttpSink[Seq[String]] {
+
+  override def httpSendMethod(request: HttpRequest, events: Seq[String]): HttpRequest = {
+    val uploadRequestBody =
+      s"""{"api_key":"$apiKey","events":[${events.mkString(",")}]}"""
+    log.info(s"Sending a batch of length ${uploadRequestBody.length} containing ${events.length} events")
+    request.postData(uploadRequestBody)
+      .header("Content-Type", "application/json")
+      .header("Accept", "*/*")
+  }
+
+  def processInBatches(events: Iterator[String]): Unit = {
+    splitIntoBatches(events).foreach(process)
+  }
+
+  /**
+    * Split an iterator of event strings into batches, each no larger than approximately maxBytesPerBatch
+    * and having fewer than maxEventsPerBatch entries such that we stay under the Amplitude batch API
+    * payload size limit of 20 MB and event count limit of 2000.
+    *
+    * See https://developers.amplitude.com/#post-batch
+    */
+  def splitIntoBatches(input: Iterator[String]): Iterator[Seq[String]] =
+    new AbstractIterator[Seq[String]] {
+      private var it: Iterator[String] = input
+
+      override def hasNext: Boolean = it.hasNext
+
+      override def next(): Seq[String] = {
+        var count: Int = 0
+        var bytes: Int = 0
+        val p = { s: String =>
+          count += 1
+          bytes += 2 * s.length
+          bytes <= maxBytesPerBatch && count <= maxEventsPerBatch
+        }
+        val (batch, remainder) = it.span(p)
+        it = remainder
+        batch.toSeq
+      }
+    }
+
+}

--- a/src/test/scala/com/mozilla/telemetry/sinks/AmplitudeBatchHttpSinkTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/sinks/AmplitudeBatchHttpSinkTest.scala
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.sinks
+
+import org.scalatest.{FlatSpec, Matchers}
+import scalaj.http.{Http, StringBodyConnectFunc}
+
+case class Event(device_id: String)
+case class UploadRequestBody(api_key: String, events: Seq[Event])
+
+class AmplitudeBatchHttpSinkTest extends FlatSpec with Matchers {
+
+  "Amplitude Batch Sink" should "split batches by size" in {
+    val testStrings = List.fill(5)("abcdefghij")
+
+    val httpSink = AmplitudeBatchHttpSink("foo", maxBytesPerBatch = 50)
+    val result: List[List[String]] = httpSink.splitIntoBatches(testStrings.iterator).map(_.toList).toList
+
+    result should contain theSameElementsAs
+      List(List("abcdefghij", "abcdefghij"), List("abcdefghij", "abcdefghij"), List("abcdefghij"))
+  }
+
+  it should "split batches by count" in {
+    val testStrings = List.fill(5)("abcdefghij")
+
+    val httpSink = AmplitudeBatchHttpSink("foo", maxEventsPerBatch = 2)
+    val result: List[List[String]] = httpSink.splitIntoBatches(testStrings.iterator).map(_.toList).toList
+
+    result should contain theSameElementsAs
+      List(List("abcdefghij", "abcdefghij"), List("abcdefghij", "abcdefghij"), List("abcdefghij"))
+  }
+
+  it should "produce valid JSON" in {
+    import org.json4s._
+    import org.json4s.jackson.Serialization
+    import org.json4s.jackson.Serialization.{read, write}
+    implicit val formats = Serialization.formats(NoTypeHints)
+
+    val events = Seq(Event("abcde"), Event("fghei"))
+
+    Seq(UploadRequestBody("foo", Seq.empty)) should have length 1
+
+    val httpSink = AmplitudeBatchHttpSink("foo")
+    val bodyStr = httpSink
+      .httpSendMethod(Http(httpSink.url), events.map(write(_)))
+      .connectFunc.asInstanceOf[StringBodyConnectFunc].data
+
+    val body = read[UploadRequestBody](bodyStr)
+    body.api_key should be ("foo")
+    body.events should contain theSameElementsAs events
+  }
+
+}

--- a/src/test/scala/com/mozilla/telemetry/streaming/EventsToAmplitudeTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/EventsToAmplitudeTest.scala
@@ -205,7 +205,7 @@ class EventsToAmplitudeTest extends FlatSpec with Matchers with BeforeAndAfterAl
     val msgs = TestUtils.generateFocusEventMessages(expectedTotalMsgs)
     val sink = sinks.AmplitudeHttpSink(apiKey, s"http://$Host:$Port$path")
 
-    msgs.foreach(m => sink.process(SendsToAmplitude(m).getAmplitudeEvents(config).get))
+    msgs.foreach(m => sink.process(SendsToAmplitude(m).getAmplitudeEvents(config).get.eventArrayString))
 
     verify(expectedTotalMsgs, postRequestedFor(urlMatching(path)))
     verify(expectedTotalMsgs, createMatcher(focusEventJsonMatch))
@@ -217,7 +217,7 @@ class EventsToAmplitudeTest extends FlatSpec with Matchers with BeforeAndAfterAl
       customPayload=EventsToAmplitudeTest.CustomMainPingPayload)
     val sink = sinks.AmplitudeHttpSink(apiKey, s"http://$Host:$Port$path")
 
-    msgs.foreach(m => sink.process(SendsToAmplitude(m).getAmplitudeEvents(config).get))
+    msgs.foreach(m => sink.process(SendsToAmplitude(m).getAmplitudeEvents(config).get.eventArrayString))
 
     verify(expectedTotalMsgs, postRequestedFor(urlMatching(path)))
     verify(expectedTotalMsgs, createMatcher(mainPingJsonMatch))
@@ -386,7 +386,7 @@ class EventsToAmplitudeTest extends FlatSpec with Matchers with BeforeAndAfterAl
       customPayload=EventsToAmplitudeTest.sessionIdOffsetPayload).head
 
     val res = for {
-      JObject(l) <- parse(SendsToAmplitude(msg).getAmplitudeEvents(config).get) \\ "session_id"
+      JObject(l) <- parse(SendsToAmplitude(msg).getAmplitudeEvents(config).get.eventArrayString) \\ "session_id"
       JField("session_id", JInt(session_id)) <- l
     } yield session_id
 


### PR DESCRIPTION
As discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1484819 we can likely achieve significantly higher throughput by using the /batch endpoint.

This PR also adds partitioning by client ID, so that each partition contains a subset of IDs. Amplitude throttles per device_id, so this keeps the effects of a throttled device more localized.

I've tested this code on ATMO by sending some events via the batch endpoint to the Savant_Dev project, and received zero errors while doing so.

Note that jobs still pass in the endpoint to use, so merging this change should have no effect on how currently configured jobs run. To switch Airflow jobs to the /batch endpoint will require a PR to telemetry-airflow.