### PR TITLE
Add beta and aurora to devtools e2a config

### DIFF
--- a/configs/devtools_events_schemas.json
+++ b/configs/devtools_events_schemas.json
@@ -9,7 +9,9 @@
       "Firefox"
     ],
     "appUpdateChannel": [
-      "nightly"
+      "nightly",
+      "beta",
+      "aurora"
     ]
   },
   "eventGroups": [


### PR DESCRIPTION
The devtools team would like to start playing with this data now that 63 is on beta/aurora