### PR TITLE
Default to a per-job streaming checkpoint location

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/CrashesToInflux.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/CrashesToInflux.scala
@@ -6,6 +6,7 @@ package com.mozilla.telemetry.streaming
 import com.mozilla.telemetry.sinks.{CrashesBatchHttpSink, HttpSink}
 
 object CrashesToInflux extends CrashPingStreamingBase {
+  override val JobName: String = "crahses_to_influx"
 
   override val sparkAppName: String = this.getClass.getSimpleName
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/CrashesToOpenTsdb.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/CrashesToOpenTsdb.scala
@@ -6,6 +6,7 @@ package com.mozilla.telemetry.streaming
 import com.mozilla.telemetry.sinks.{CrashesBatchHttpSink, HttpSink}
 
 object CrashesToOpenTsdb extends CrashPingStreamingBase {
+  override val JobName: String = "crashes_to_opentsdb"
 
   override val sparkAppName: String = this.getClass.getSimpleName
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql.types.StructType
 
 object ErrorAggregator extends ErrorAggregatorBase {
 
+  override val JobName: String = "error_aggregator"
 
   override val outputPrefix = "error_aggregator/v2"
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/EventPingEvents.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/EventPingEvents.scala
@@ -10,6 +10,9 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.rogach.scallop.ScallopOption
 
 object EventPingEvents extends StreamingJobBase {
+
+  override val JobName: String = "event_ping_events"
+
   override val outputPrefix = "events/v1"
 
   val kafkaCacheMaxCapacity = 10

--- a/src/main/scala/com/mozilla/telemetry/streaming/EventsToAmplitude.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/EventsToAmplitude.scala
@@ -37,6 +37,8 @@ import scala.io.Source
  */
 object EventsToAmplitude extends StreamingJobBase {
 
+  override val JobName: String = "events_to_amplitude"
+
   val log: org.apache.log4j.Logger = org.apache.log4j.LogManager.getLogger(this.getClass.getName)
 
   val AMPLITUDE_API_KEY_KEY = "AMPLITUDE_API_KEY"

--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentEnrollmentsAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentEnrollmentsAggregator.scala
@@ -13,6 +13,8 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.rogach.scallop.ScallopOption
 
 object ExperimentEnrollmentsAggregator extends StreamingJobBase {
+  override val JobName: String = "experiment_enrollments_aggregator"
+
   override val outputPrefix = "experiment_enrollments/v1"
 
   val kafkaCacheMaxCapacity = 100

--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentEnrollmentsToTestTube.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentEnrollmentsToTestTube.scala
@@ -16,6 +16,7 @@ import org.json4s.jackson.Serialization
 import org.rogach.scallop.ScallopOption
 
 object ExperimentEnrollmentsToTestTube extends StreamingJobBase {
+  override val JobName: String = "experiment_enrollments_to_test_tube"
   val MaxParalellRequests = 10
   val kafkaCacheMaxCapacity = 100
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsEnrollmentsToDatadog.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsEnrollmentsToDatadog.scala
@@ -13,6 +13,8 @@ import org.rogach.scallop.ScallopOption
 
 
 object ExperimentsEnrollmentsToDatadog extends StreamingJobBase {
+  override val JobName: String = "experiment_enrollments_to_datadog"
+
   val kafkaCacheMaxCapacity = 100
 
   private val allowedDocTypes = List("main", "event")

--- a/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ExperimentsErrorAggregator.scala
@@ -9,6 +9,7 @@ import com.mozilla.telemetry.timeseries.SchemaBuilder
 import org.apache.spark.sql.types.StructType
 
 object ExperimentsErrorAggregator extends ErrorAggregatorBase {
+  override val JobName: String = "expeirments_error_aggregator"
 
   override val outputPrefix = "experiment_error_aggregates/v1"
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -18,6 +18,7 @@ import com.mozilla.telemetry.util.PrettyPrint
 import scala.collection.mutable
 
 object FederatedLearningSearchOptimizer extends StreamingJobBase {
+  override val JobName: String = "federated_learning_search_optimizer"
 
   def main(args: Array[String]): Unit = {
     val opts = new Opts(args)

--- a/src/main/scala/com/mozilla/telemetry/streaming/StreamingJobBase.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/StreamingJobBase.scala
@@ -23,6 +23,11 @@ abstract class StreamingJobBase extends Serializable {
   val QueryName: String = "main_query"
 
   /**
+    * Abstract job name must be defined in concrete children
+    */
+  val JobName: String
+
+  /**
     * S3 output prefix with version number
     */
   val outputPrefix: String = ""
@@ -69,7 +74,7 @@ abstract class StreamingJobBase extends Serializable {
       "checkpointPath",
       descr = "Checkpoint path (streaming mode only)",
       required = false,
-      default = Some("/tmp/checkpoint"))
+      default = Some(s"/tmp/checkpoints/$JobName"))
     val from: ScallopOption[String] = opt[String](
       "from",
       descr = "Start submission date (batch mode only). Format: YYYYMMDD",

--- a/src/test/scala/com/mozilla/telemetry/streaming/CrashPingStreamingBaseTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/CrashPingStreamingBaseTest.scala
@@ -16,6 +16,7 @@ import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 class CrashPingStreamingBaseTest extends FlatSpec with Matchers with BeforeAndAfterEach with DataFrameSuiteBase {
 
   private val CrashPingStreaming = new CrashPingStreamingBase {
+    override val JobName: String = "crash_ping_streaming_test"
     override val sparkAppName: String = "CrashPingStreaming"
 
     override def buildOutputString(measurementName: String, timestamp: Long, buildId: String, tags: Map[String, String]): String = {

--- a/src/test/scala/com/mozilla/telemetry/streaming/StreamingJobBaseTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/StreamingJobBaseTest.scala
@@ -10,6 +10,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class StreamingJobBaseTest extends FlatSpec with Matchers {
   private val base = new StreamingJobBase {
+    override val JobName: String = "streaming_job_base_test"
     override val clock: Clock = Clock.fixed(
       LocalDate.of(2018, 4, 5).atStartOfDay(ZoneId.of("UTC")).toInstant, ZoneId.of("UTC"))
   }


### PR DESCRIPTION
As discussed as we were looking to remediate the streaming jobs contributing to the kafka outage -- Adds a JobName value to the streaming base class and sets the default checkpoint using this value.