### PR TITLE
Bug 1507238: Cast sample_id to int before converting to string

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
@@ -169,6 +169,11 @@ case class Meta(Host: Option[String],
   def normalizedTimestamp(): Timestamp = {
     new Timestamp(this.Timestamp / 1000000)
   }
+
+  // Bug 1507238: don't forget to map to an int before converting to a string or we'll end up with `42.0`
+  def stringSampleId: Option[String] = {
+    sampleId.map(_.toInt.toString())
+  }
 }
 
 object Meta {

--- a/src/main/scala/com/mozilla/telemetry/streaming/EventPingEvents.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/EventPingEvents.scala
@@ -128,7 +128,7 @@ object EventPingEvents extends StreamingJobBase {
               EventRow(ping.meta.documentId.get, ping.meta.clientId.get, ping.meta.normalizedChannel, ping.meta.geoCountry,
                 ping.getLocale, ping.meta.appName, ping.meta.appVersion, ping.getOsName, ping.getOsVersion,
                 ping.payload.sessionId, ping.payload.subsessionId, ping.sessionStart,
-                (ping.meta.Timestamp / 1e9).toLong, ping.meta.sampleId.map(_.toString), ping.getMSStyleExperiments,
+                (ping.meta.Timestamp / 1e9).toLong, ping.meta.stringSampleId, ping.getMSStyleExperiments,
                 e.timestamp, e.category, e.method, e.`object`, e.value, extra, process)
             }
           }

--- a/src/test/scala/com/mozilla/telemetry/streaming/EventPingEventsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/EventPingEventsTest.scala
@@ -29,4 +29,25 @@ class EventPingEventsTest extends FlatSpec with Matchers with DataFrameSuiteBase
           "session_id" -> "{78fe2428-15fb-4448-b517-cbb85f22def0}", "page" -> "about:newtab")), "parent"))
   }
 
+  "Event Ping Events" should "output sampleIds without decimal points" in {
+    import spark.implicits._
+
+    val messageDF = spark.sparkContext.parallelize(
+      TestUtils.generateEventMessages(1, fieldsOverride = Some(Map("sampleId" -> 42L))).map(_.toByteArray)
+    ).toDF("value")
+
+    val results = EventPingEvents.explodeEvents(messageDF).persist
+
+    results.count should be(4)
+    results.filter("event_process = 'parent'").count == 2
+    results.filter("event_process = 'dynamic'").count == 2
+    results.first should be(
+      EventPingEvents.EventRow("an_id", "client1", "release", "IT", None, "Firefox", "42.0", Some("Linux"), Some("42"),
+        "dd302e9d-569b-4058-b7e8-02b2ff83522c", "79a2728f-af12-4ed3-b56d-0531a03c2f26", 1530291900000L, 1460036116,
+        Some("42"), Some(Map("experiment2" -> "chaos", "experiment1" -> "control")), 4118829, "activity_stream", "end",
+        "session", Some("909"),
+        Some(Map("addon_version" -> "2018.06.22.1337-8d599e17", "user_prefs" -> "63",
+          "session_id" -> "{78fe2428-15fb-4448-b517-cbb85f22def0}", "page" -> "about:newtab")), "parent"))
+  }
+
 }


### PR DESCRIPTION
Per the discovery this morning that sample_id in event ping events takes the form of `42.0` -- I briefly considered switching sampleId in the Meta class to be `Option[Double]` but unfortunately we have a lot of data in amplitude already that has sampleId in that form (which isn't a problem as long as it's consistent per project)