### PR TITLE
Bug 1509120 - Fix NullPointerException on OS version normalization

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/Ping.scala
@@ -191,18 +191,18 @@ case class EnvironmentBuild(version: Option[String],
 case class System(os: SystemOs, isWow64: Option[Boolean], memoryMB: Option[Double])
 
 case class SystemOs(name: String, version: String) {
-  val normalizedVersion: String = OS(Option(name), Option(version)).normalizedVersion
+  val normalizedVersion: Option[String] = OS(Option(name), Option(version)).normalizedVersion
 }
 
 case class OS(name: Option[String], version: Option[String]) {
   val versionRegex = "(\\d+(\\.\\d+)?(\\.\\d+)?)?.*".r
-  val normalizedVersion: String = {
+  val normalizedVersion: Option[String] = {
     version match {
       case Some(v) =>
         val versionRegex(normalized, _, _) = v
-        normalized
+        Option(normalized)
       case None =>
-        null
+        None
     }
   }
 }
@@ -263,7 +263,7 @@ trait HasEnvironment {
 
   override def getOsName: Option[String] = meta.`environment.system`.map(_.os.name)
 
-  override def getOsVersion: Option[String] = meta.`environment.system`.map(_.os.normalizedVersion)
+  override def getOsVersion: Option[String] = meta.`environment.system`.flatMap(_.os.normalizedVersion)
 
   override def getArchitecture: Option[String] = meta.`environment.build`.flatMap(_.architecture)
 

--- a/src/test/scala/com/mozilla/telemetry/pings/PingsTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/PingsTest.scala
@@ -107,16 +107,16 @@ class PingsTest extends FlatSpec with Matchers{
   }
 
   "An OS instance" should "normalize the version" in {
-    OS(Some("linux"), Some("1.1.1-ignore")).normalizedVersion should be ("1.1.1")
-    OS(Some("linux"), Some("1.1.1ignore")).normalizedVersion should be ("1.1.1")
-    OS(Some("linux"), Some("1.1")).normalizedVersion should be ("1.1")
-    OS(Some("linux"), Some("1.1-ignore")).normalizedVersion should be ("1.1")
-    OS(Some("linux"), Some("1.1ignore")).normalizedVersion should be ("1.1")
-    OS(Some("linux"), Some("1")).normalizedVersion should be ("1")
-    OS(Some("linux"), Some("1-ignore")).normalizedVersion should be ("1")
-    OS(Some("linux"), Some("1ignore")).normalizedVersion should be ("1")
-    OS(Some("linux"), Some("non-numeric")).normalizedVersion should be (null)
-    OS(Some("linux"), Some("nonnumeric1.1")).normalizedVersion should be (null)
+    OS(Some("linux"), Some("1.1.1-ignore")).normalizedVersion shouldBe Some("1.1.1")
+    OS(Some("linux"), Some("1.1.1ignore")).normalizedVersion shouldBe Some("1.1.1")
+    OS(Some("linux"), Some("1.1")).normalizedVersion shouldBe Some("1.1")
+    OS(Some("linux"), Some("1.1-ignore")).normalizedVersion shouldBe Some("1.1")
+    OS(Some("linux"), Some("1.1ignore")).normalizedVersion shouldBe Some("1.1")
+    OS(Some("linux"), Some("1")).normalizedVersion shouldBe Some("1")
+    OS(Some("linux"), Some("1-ignore")).normalizedVersion shouldBe Some("1")
+    OS(Some("linux"), Some("1ignore")).normalizedVersion shouldBe Some("1")
+    OS(Some("linux"), Some("non-numeric")).normalizedVersion shouldBe None
+    OS(Some("linux"), Some("nonnumeric1.1")).normalizedVersion shouldBe None
   }
 
   "Main Ping" can "read events" in {


### PR DESCRIPTION
This fixes Event Ping Events job failing with null pointer exception.

The reason was:
`OS#normalizedVersion` could return null if `version` string was empty (https://github.com/mozilla/telemetry-streaming/pull/188/files#diff-be261a172bbe8ba3137a937df3a3f5c6R199).
This caused `Ping#getOsVersion` to return `Some(null)` (https://github.com/mozilla/telemetry-streaming/pull/188/files#diff-be261a172bbe8ba3137a937df3a3f5c6R266).

Test runs (3rd one is with this fix applied): https://dbc-caf9527b-e073.cloud.databricks.com/#job/756