### PR TITLE
E2A updates for devtools release job

### DIFF
--- a/configs/devtools_release_schemas.json
+++ b/configs/devtools_release_schemas.json
@@ -2,7 +2,6 @@
   "source": "telemetry",
   "filters": {
     "docType": [
-      "main",
       "event"
     ],
     "appName": [


### PR DESCRIPTION
* Only look for events in the events ping
* Add a partition multiplier option (sped up the filter/explode stage significantly in manual runs)