### PR TITLE
Patch for federated learning v2 experiment

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -64,10 +64,15 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
         val docType = fields.getOrElse("docType", "").asInstanceOf[String]
         if ("frecency-update" == docType) {
           val ping = FrecencyUpdatePing(m)
-          if ((ping.payload.study_variation contains "training") && (ping.payload.bookmark_and_history_num_suggestions_displayed > -1)) {
+          if (((ping.payload.study_variation contains "training") || 
+               (ping.payload.study_variation.startsWith("dogfooding")))
+            && (ping.payload.bookmark_and_history_num_suggestions_displayed > -1)) {
+
+            val model_version  = if (ping.payload.model_version == -1) Int.MaxValue else ping.payload.model_version
+
             Option(FrecencyUpdate(
               new Timestamp(clock.millis()),
-              ping.payload.model_version,
+              model_version,
               ping.payload.loss,
               ping.payload.update,
               ping.meta.clientId

--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -64,7 +64,7 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
         val docType = fields.getOrElse("docType", "").asInstanceOf[String]
         if ("frecency-update" == docType) {
           val ping = FrecencyUpdatePing(m)
-          if (((ping.payload.study_variation contains "training") || 
+          if (((ping.payload.study_variation contains "training") ||
                (ping.payload.study_variation.startsWith("dogfooding")))
             && (ping.payload.bookmark_and_history_num_suggestions_displayed > -1)) {
 

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -511,6 +511,8 @@ object TestUtils {
   }
 
   def generateFrecencyUpdateMessages(size: Int,
+                                     modelVersion: Int,
+                                     variation: String = "training",
                                      fieldsOverride: Option[Map[String, Any]] = None,
                                      timestamp: Option[Long] = None): Seq[Message] = {
     val defaultMap = Map(
@@ -533,7 +535,7 @@ object TestUtils {
     val applicationJson = compact(render(Extraction.decompose(defaultFirefoxApplication)))
     val payload =
       s"""
-       |    "model_version": 140,
+       |    "model_version": $modelVersion,
        |    "frecency_scores": [38223, 3933.4, 304933.3, 21],
        |    "loss": 291989.21,
        |    "update": [
@@ -573,7 +575,7 @@ object TestUtils {
        |    "selected_style": "autofill heuristic",
        |    "selected_url_was_same_as_search_string": 0,
        |    "enter_was_pressed": 1,
-       |    "study_variation": "training",
+       |    "study_variation": "$variation",
        |    "study_addon_version": "2.1.1"
        """.stripMargin
     1.to(size) map { index =>

--- a/src/test/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizerTest.scala
@@ -67,7 +67,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
 
     When("they're aggregated")
     val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), clock, 28)
-      .writeStream.format("memory").option("checkpointLocation", CheckpointPath+"/spark").queryName("updates").start()
+      .writeStream.format("memory").option("checkpointLocation", CheckpointPath + "/spark").queryName("updates").start()
     pingsStream.addData(pings)
     query.processAllAvailable()
 
@@ -97,7 +97,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
 
     When("they're aggregated")
     val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), clock, 28)
-      .writeStream.format("memory").option("checkpointLocation", CheckpointPath+"/spark").queryName("updates").start()
+      .writeStream.format("memory").option("checkpointLocation", CheckpointPath + "/spark").queryName("updates").start()
     pingsStream.addData(pings)
     query.processAllAvailable()
 
@@ -127,7 +127,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
 
     When("they're aggregated")
     val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), clock, 28)
-      .writeStream.format("memory").option("checkpointLocation", CheckpointPath+"/spark").queryName("updates").start()
+      .writeStream.format("memory").option("checkpointLocation", CheckpointPath + "/spark").queryName("updates").start()
     pingsStream.addData(pings)
     query.processAllAvailable()
 
@@ -157,7 +157,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
 
     When("they're aggregated")
     val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), clock, 28)
-      .writeStream.format("memory").option("checkpointLocation", CheckpointPath+"/spark").queryName("updates").start()
+      .writeStream.format("memory").option("checkpointLocation", CheckpointPath + "/spark").queryName("updates").start()
     pingsStream.addData(pings)
     query.processAllAvailable()
 
@@ -187,7 +187,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
 
     When("they're aggregated")
     val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), clock, 28)
-      .writeStream.format("memory").option("checkpointLocation", CheckpointPath+"/spark").queryName("updates").start()
+      .writeStream.format("memory").option("checkpointLocation", CheckpointPath + "/spark").queryName("updates").start()
     pingsStream.addData(pings)
     query.processAllAvailable()
 
@@ -217,7 +217,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
 
     When("they're aggregated")
     val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), clock, 28)
-      .writeStream.format("memory").option("checkpointLocation", CheckpointPath+"/spark").queryName("updates").start()
+      .writeStream.format("memory").option("checkpointLocation", CheckpointPath + "/spark").queryName("updates").start()
     pingsStream.addData(pings)
     query.processAllAvailable()
 
@@ -247,7 +247,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
 
     When("they're aggregated")
     val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), clock, 28)
-      .writeStream.format("memory").option("checkpointLocation", CheckpointPath+"/spark").queryName("updates").start()
+      .writeStream.format("memory").option("checkpointLocation", CheckpointPath + "/spark").queryName("updates").start()
     pingsStream.addData(pings)
     query.processAllAvailable()
 


### PR DESCRIPTION
This patch changes a couple things:

The filtering has been updated to match the branch definitions in https://github.com/mozilla/federated-learning-v2-study-addon/blob/master/src/feature.js#L6

* Any dogfooding or training branch will be included for inbound pings.
* Training pings where models are never downloaded from S3 will have the modelVersion clobbered with Int.MaxValue 
* Test cases for each of the branches has been added with a modelVersion that reflects whether or not the client will submit a -1 value based on the `validation` flag for the branch