### PR TITLE
Patch to add a modelBranch argument to the Federated Learning v2 study

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -74,7 +74,13 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
         val docType = fields.getOrElse("docType", "").asInstanceOf[String]
         if ("frecency-update" == docType) {
           val ping = FrecencyUpdatePing(m)
-          if ((ping.payload.study_variation startsWith variationTarget) && (ping.payload.bookmark_and_history_num_suggestions_displayed > -1)) {
+          if (
+              (
+               (ping.payload.study_variation startsWith variationTarget) &&
+              !(ping.payload.study_variation contains "not-submitting")
+              ) &&
+              ( ping.payload.bookmark_and_history_num_suggestions_displayed > -1)
+            ) {
             Option(FrecencyUpdate(
               new Timestamp(clock.millis()),
               ping.payload.model_version,

--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -40,22 +40,32 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
       .select("value")
 
     val query = optimize(pings,
-      opts.checkpointPath(), opts.modelOutputBucket(), opts.modelOutputKey(), opts.stateCheckpointPath(),
-      opts.stateBootstrapFilePath.get, Clock.systemUTC(), opts.windowOffsetMinutes(), opts.raiseOnError(),
-      opts.s3EndpointOverride.get)
+      opts.checkpointPath(), opts.modelOutputBucket(),
+      opts.modelOutputKey(), opts.modelBranch(),
+      opts.stateCheckpointPath(), opts.stateBootstrapFilePath.get,
+      Clock.systemUTC(), opts.windowOffsetMinutes(),
+      opts.raiseOnError(), opts.s3EndpointOverride.get)
 
     query.awaitTermination()
   }
 
   def optimize(pings: DataFrame, checkpointPath: String, modelOutputBucket: String, modelOutputKey: String, // scalastyle:ignore
-               stateCheckpointPath: String, stateBootstrapFilePath: Option[String] = None,
+               modelBranch: Int, stateCheckpointPath: String, stateBootstrapFilePath: Option[String] = None,
                clock: Clock, windowOffsetMin: Int, raiseOnError: Boolean = false, s3EndpointOverride: Option[String] = None): StreamingQuery = {
-    val aggregates = aggregate(pings, clock, windowOffsetMin, raiseOnError)
+    val aggregates = aggregate(pings, modelBranch, clock, windowOffsetMin, raiseOnError)
     writeUpdates(aggregates, checkpointPath, modelOutputBucket, modelOutputKey, stateCheckpointPath, stateBootstrapFilePath, s3EndpointOverride)
   }
 
-  def aggregate(pings: DataFrame, clock: Clock, windowOffsetMin: Int, raiseOnError: Boolean = false): Dataset[FrecencyUpdateAggregate] = {
+  def aggregate(pings: DataFrame, modelBranch: Int, clock: Clock, windowOffsetMin: Int, raiseOnError: Boolean = false): Dataset[FrecencyUpdateAggregate] = {
     import pings.sparkSession.implicits._
+
+
+    val variationTarget: String = modelBranch match {
+      case 1 => "model1"
+      case 2 => "model2"
+      case 3 => "model3"
+      case 4 => "model4"
+    }
 
     val frecencyUpdates: Dataset[FrecencyUpdate] = pings.flatMap { v =>
       try {
@@ -64,7 +74,7 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
         val docType = fields.getOrElse("docType", "").asInstanceOf[String]
         if ("frecency-update" == docType) {
           val ping = FrecencyUpdatePing(m)
-          if ((ping.payload.study_variation contains "training") && (ping.payload.bookmark_and_history_num_suggestions_displayed > -1)) {
+          if ((ping.payload.study_variation startsWith variationTarget) && (ping.payload.bookmark_and_history_num_suggestions_displayed > -1)) {
             Option(FrecencyUpdate(
               new Timestamp(clock.millis()),
               ping.payload.model_version,
@@ -98,7 +108,9 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
   }
 
   def writeUpdates(aggregates: Dataset[FrecencyUpdateAggregate], checkpointPath: String, modelOutputBucket: String, modelOutputKey: String,
-                   stateCheckpointPath: String, stateBootstrapFilePath: Option[String], s3EndpointOverride: Option[String] = None): StreamingQuery = {
+          stateCheckpointPath: String,
+          stateBootstrapFilePath: Option[String], s3EndpointOverride:
+          Option[String] = None): StreamingQuery = {
     val writer = aggregates.writeStream
       .format("com.mozilla.telemetry.learning.federated.FederatedLearningSearchOptimizerS3SinkProvider")
       .option("checkpointLocation", checkpointPath)
@@ -128,6 +140,10 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
     val modelOutputKey: ScallopOption[String] = opt[String](
       name = "modelOutputKey",
       descr = "S3 key to save public model iterations",
+      required = true)
+    val modelBranch: ScallopOption[Int] = opt[Int](
+      name = "modelBranch",
+      descr = "Experiment model branch that we are going to be updating",
       required = true)
     val stateCheckpointPath: ScallopOption[String] = opt[String](
       name = "stateCheckpointPath",

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -512,7 +512,8 @@ object TestUtils {
 
   def generateFrecencyUpdateMessages(size: Int,
                                      fieldsOverride: Option[Map[String, Any]] = None,
-                                     timestamp: Option[Long] = None): Seq[Message] = {
+                                     timestamp: Option[Long] = None,
+                                     modelBranch: String = "model1"): Seq[Message] = {
     val defaultMap = Map(
       "clientId" -> "client1",
       "docType" -> "frecency-update",
@@ -573,7 +574,7 @@ object TestUtils {
        |    "selected_style": "autofill heuristic",
        |    "selected_url_was_same_as_search_string": 0,
        |    "enter_was_pressed": 1,
-       |    "study_variation": "training",
+       |    "study_variation": "${modelBranch}",
        |    "study_addon_version": "2.1.1"
        """.stripMargin
     1.to(size) map { index =>

--- a/src/test/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizerTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizerTest.scala
@@ -35,7 +35,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
     val pingsStream = MemoryStream[Array[Byte]]
 
     When("they're aggregated")
-    val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), 1, clock, 28)
+    val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), "model1", clock, 28)
       .writeStream.format("memory").queryName("updates").start()
       pingsStream.addData(pings)
       query.processAllAvailable()
@@ -65,7 +65,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
     val pingsStream = MemoryStream[Array[Byte]]
 
     When("they're aggregated")
-    val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), 1, clock, 28)
+    val query = FederatedLearningSearchOptimizer.aggregate(pingsStream.toDF(), "model1", clock, 28)
       .writeStream.format("memory").queryName("updates_ignored").start()
     pingsStream.addData(pings)
     query.processAllAvailable()
@@ -99,7 +99,7 @@ class FederatedLearningSearchOptimizerTest extends FlatSpec with Matchers with G
 
     val s3 = S3TestUtil(MockEndpointPort, Some(OutputBucket))
     val query = FederatedLearningSearchOptimizer.optimize(pingsStream.toDF(), CheckpointPath + "/spark", OutputBucket,
-      OutputKey, 1, CheckpointPath, None, clock, 28, s3EndpointOverride = Some(MockEndpoint))
+      OutputKey, "model1", CheckpointPath, None, clock, 28, s3EndpointOverride = Some(MockEndpoint))
     pingsStream.addData(pings)
     query.processAllAvailable()
 


### PR DESCRIPTION
The Federated Learning v2 experiment needs to have an extra parameter
passed in to distinguish between the 4 different models that need to be
trained.

The filter to select relevant pings has been updatd.

Extra test case added demonstrating filtering the aggregation step by
using the variation name to drop ignorable pings.