### PR TITLE
added option for failOnDataLoss to be false to skip over aged out data

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -36,6 +36,7 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
       .option("spark.streaming.kafka.consumer.cache.maxCapacity", 100)
       .option("subscribe", TelemetryKafkaTopic)
       .option("startingOffsets", opts.startingOffsets())
+      .option("failOnDataLoss", false)
       .load()
       .select("value")
 

--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -36,7 +36,7 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
       .option("spark.streaming.kafka.consumer.cache.maxCapacity", 100)
       .option("subscribe", TelemetryKafkaTopic)
       .option("startingOffsets", opts.startingOffsets())
-      .option("failOnDataLoss", false)
+      .option("failOnDataLoss", opts.failOnDataLoss())
       .load()
       .select("value")
 
@@ -132,6 +132,9 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
   }
 
   private class Opts(args: Array[String]) extends BaseOpts(args) {
+    val failOnDataLoss:ScallopOption[Boolean] = opt[Boolean](
+      descr = "Whether to fail the query when it’s possible that data is lost.",
+      default=Some(false))
     val modelOutputBucket: ScallopOption[String] = opt[String](
       name = "modelOutputBucket",
       descr = "S3 bucket to save public model iterations",

--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -132,7 +132,7 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
   }
 
   private class Opts(args: Array[String]) extends BaseOpts(args) {
-    val failOnDataLoss:ScallopOption[Boolean] = opt[Boolean](
+    val failOnDataLoss: ScallopOption[Boolean] = opt[Boolean](
       descr = "Whether to fail the query when it’s possible that data is lost.",
       default=Some(false))
     val modelOutputBucket: ScallopOption[String] = opt[String](

--- a/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/FederatedLearningSearchOptimizer.scala
@@ -134,7 +134,7 @@ object FederatedLearningSearchOptimizer extends StreamingJobBase {
   private class Opts(args: Array[String]) extends BaseOpts(args) {
     val failOnDataLoss: ScallopOption[Boolean] = opt[Boolean](
       descr = "Whether to fail the query when it’s possible that data is lost.",
-      default=Some(false))
+      default = Some(false))
     val modelOutputBucket: ScallopOption[String] = opt[String](
       name = "modelOutputBucket",
       descr = "S3 bucket to save public model iterations",


### PR DESCRIPTION
This enables skipping over data loss for the federated learning streaming jobs.

See bug https://bugzilla.mozilla.org/show_bug.cgi?id=1540562

