### PR TITLE
Bug 1538793: look for Normandy events from all processes

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/pings/EventPing.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/EventPing.scala
@@ -40,8 +40,7 @@ case class EventPing(application: Application,
   }
 
   def getNormandyEvents: Seq[Event] = {
-    val dynamicProcessEvents = processEventMap.getOrElse("dynamic", Seq.empty[Event])
-    dynamicProcessEvents.filter(_.category == "normandy")
+    events.filter(_.category == "normandy")
   }
 }
 

--- a/src/test/scala/com/mozilla/telemetry/TestUtils.scala
+++ b/src/test/scala/com/mozilla/telemetry/TestUtils.scala
@@ -394,7 +394,9 @@ object TestUtils {
 
   def generateEventMessages(size: Int,
                             fieldsOverride: Option[Map[String, Any]] = None,
-                            timestamp: Option[Long] = None): Seq[Message] = {
+                            timestamp: Option[Long] = None,
+                            customPayload: Option[String] = None
+                           ): Seq[Message] = {
     val defaultMap = Map(
       "clientId" -> "client1",
       "docType" -> "event",
@@ -442,8 +444,7 @@ object TestUtils {
       case _ => defaultMap
     }
     val applicationJson = compact(render(Extraction.decompose(defaultFirefoxApplication)))
-    val payload =
-      s"""
+    val payload = customPayload.getOrElse(s"""
          |    "reason": "periodic",
          |    "processStartTimestamp": 1530291900000,
          |    "sessionId": "dd302e9d-569b-4058-b7e8-02b2ff83522c",
@@ -495,7 +496,7 @@ object TestUtils {
          |        ]
          |      ]
          |    }
-       """.stripMargin
+       """.stripMargin)
     1.to(size) map { index =>
       RichMessage(s"event-$index",
         outputMap,


### PR DESCRIPTION
Enrollment monitoring for the FX quantum bar HTML (vs XUL) experiment was broken -- turns out it was because normandy events moved to the parent process in 67, and the experiment was running in Nightly ([bug for that change](https://bugzilla.mozilla.org/show_bug.cgi?id=1443560))

`EventPing.getNormandyEvents` now looks for normandy pings in all events. I left the MainPing as-is since events in the Main Ping should be considered legacy at this point.