### PR TITLE
Bug 1530997 - Ship new runtime_connected extras to Amplitude

### DIFF
--- a/configs/devtools_prerelease_schemas.json
+++ b/configs/devtools_prerelease_schemas.json
@@ -1264,7 +1264,9 @@
             "connection_type": "extra.connection_type",
             "device_name": "extra.device_name",
             "runtime_id": "extra.runtime_id",
-            "runtime_name": "extra.runtime_name"
+            "runtime_name": "extra.runtime_name",
+	    "runtime_os": "extra.runtime_os",
+	    "runtime_version": "extra.runtime_version"
           },
           "sessionIdOffset": "extra.session_id",
           "description": "",

--- a/configs/devtools_prerelease_schemas.json
+++ b/configs/devtools_prerelease_schemas.json
@@ -1265,8 +1265,8 @@
             "device_name": "extra.device_name",
             "runtime_id": "extra.runtime_id",
             "runtime_name": "extra.runtime_name",
-	    "runtime_os": "extra.runtime_os",
-	    "runtime_version": "extra.runtime_version"
+            "runtime_os": "extra.runtime_os",
+            "runtime_version": "extra.runtime_version"
           },
           "sessionIdOffset": "extra.session_id",
           "description": "",

--- a/configs/devtools_release_schemas.json
+++ b/configs/devtools_release_schemas.json
@@ -1261,7 +1261,9 @@
             "connection_type": "extra.connection_type",
             "device_name": "extra.device_name",
             "runtime_id": "extra.runtime_id",
-            "runtime_name": "extra.runtime_name"
+            "runtime_name": "extra.runtime_name",
+	    "runtime_os": "extra.runtime_os",
+	    "runtime_version": "extra.runtime_version"
           },
           "sessionIdOffset": "extra.session_id",
           "description": "",

--- a/configs/devtools_release_schemas.json
+++ b/configs/devtools_release_schemas.json
@@ -1262,8 +1262,8 @@
             "device_name": "extra.device_name",
             "runtime_id": "extra.runtime_id",
             "runtime_name": "extra.runtime_name",
-	    "runtime_os": "extra.runtime_os",
-	    "runtime_version": "extra.runtime_version"
+            "runtime_os": "extra.runtime_os",
+            "runtime_version": "extra.runtime_version"
           },
           "sessionIdOffset": "extra.session_id",
           "description": "",


### PR DESCRIPTION
Adds runtime_os and runtime_version extras described in https://bugzilla.mozilla.org/show_bug.cgi?id=1530997 to the e2a configs for devtools.