### PR TITLE
Use driver hostname for datadog sink address in UptakeEventsToDatadog

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/UptakeEventsToDatadog.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/UptakeEventsToDatadog.scala
@@ -45,7 +45,8 @@ object UptakeEventsToDatadog extends StreamingJobBase {
       .option("failOnDataLoss", false)
       .load()
 
-    val writer = new DogStatsDMetricSink("localhost", 8125)
+    val driverAddress = spark.conf.get("spark.driver.host", "localhost")
+    val writer = new DogStatsDMetricSink(driverAddress, 8125)
 
     eventsToMetrics(pings.select("value"), opts.raiseOnError())
       .writeStream


### PR DESCRIPTION
Testing whether we can use the agent installed on the driver as the sink location